### PR TITLE
Use URL.RequestURI to construct a cache key

### DIFF
--- a/rfc/standalone.go
+++ b/rfc/standalone.go
@@ -13,7 +13,7 @@ import (
 
 // GetCacheKey returns the cache key for req.
 func GetCacheKey(req *http.Request) string {
-	return fmt.Sprintf("%s-%s-%s", req.Method, req.Host, req.URL.Path)
+	return fmt.Sprintf("%s-%s-%s", req.Method, req.Host, req.URL.RequestURI())
 }
 
 // GetVariedCacheKey returns the varied cache key for req and resp.


### PR DESCRIPTION
Otherwise things like `/shop`, `/shop?page=2`, `/shop?category_id=2`,
`/shop?product_id=42` and so on are all considered as the same resource.

Probably a more sophisticated solution is desired here, as this does not
take into account UTM parameters[1], for instance.

[1]: https://en.wikipedia.org/wiki/UTM_parameters