### PR TITLE
Feat/core/ykeys/introduction

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -3,11 +3,12 @@ package api
 import (
 	"github.com/darkweak/souin/api/auth"
 	"github.com/darkweak/souin/cache/types"
+	"github.com/darkweak/souin/cache/ykeys"
 	"github.com/darkweak/souin/configurationtypes"
 )
 
 // Initialize contains all apis that should be enabled
-func Initialize(provider types.AbstractProviderInterface, c configurationtypes.AbstractConfigurationInterface) []EndpointInterface {
+func Initialize(provider types.AbstractProviderInterface, c configurationtypes.AbstractConfigurationInterface, ykeyStorage *ykeys.YKeyStorage) []EndpointInterface {
 	security := auth.InitializeSecurity(c)
-	return []EndpointInterface{security, initializeSouin(provider, c, security)}
+	return []EndpointInterface{security, initializeSouin(provider, c, security, ykeyStorage)}
 }

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"github.com/darkweak/souin/cache/providers"
+	"github.com/darkweak/souin/cache/ykeys"
 	"github.com/darkweak/souin/errors"
 	"github.com/darkweak/souin/tests"
 	"testing"
@@ -12,7 +13,7 @@ func TestInitialize(t *testing.T) {
 	config := tests.MockConfiguration(tests.BaseConfiguration)
 	prs := providers.InitializeProvider(config)
 
-	endpoints := Initialize(prs, config)
+	endpoints := Initialize(prs, config, ykeys.InitializeYKeys(config.Ykeys))
 
 	if len(endpoints) != 2 {
 		errors.GenerateError(t, fmt.Sprintf("Endpoints length should be 1, %d received", len(endpoints)))

--- a/api/souin_test.go
+++ b/api/souin_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/darkweak/souin/api/auth"
 	"github.com/darkweak/souin/cache/providers"
+	"github.com/darkweak/souin/cache/ykeys"
 	"github.com/darkweak/souin/errors"
 	"github.com/darkweak/souin/tests"
 	"regexp"
@@ -19,6 +20,7 @@ func mockSouinAPI() *SouinAPI {
 		true,
 		prs,
 		security,
+		ykeys.InitializeYKeys(config.Ykeys),
 	}
 }
 

--- a/cache/coalescing/requestCoalescing_test.go
+++ b/cache/coalescing/requestCoalescing_test.go
@@ -3,6 +3,7 @@ package coalescing
 import (
 	"github.com/darkweak/souin/cache/providers"
 	"github.com/darkweak/souin/cache/types"
+	"github.com/darkweak/souin/cache/ykeys"
 	"github.com/darkweak/souin/helpers"
 	"github.com/darkweak/souin/rfc"
 	"github.com/darkweak/souin/tests"
@@ -20,7 +21,7 @@ func commonInitializer() (*httptest.ResponseRecorder, *http.Request, *types.Retr
 		Provider:      prs,
 		MatchedURL:    tests.GetMatchedURL(tests.PATH),
 		RegexpUrls:    regexpUrls,
-		Transport:     rfc.NewTransport(prs),
+		Transport:     rfc.NewTransport(prs, ykeys.InitializeYKeys(c.Ykeys)),
 	}
 	r := httptest.NewRequest("GET", "http://"+tests.DOMAIN+tests.PATH, nil)
 	w := httptest.NewRecorder()

--- a/cache/types/souin.go
+++ b/cache/types/souin.go
@@ -15,6 +15,7 @@ type TransportInterface interface {
 	UpdateCacheEventually(req *http.Request) (resp *http.Response, err error)
 	GetVaryLayerStorage() *VaryLayerStorage
 	GetCoalescingLayerStorage() *CoalescingLayerStorage
+	GetYkeyStorage() *ykeys.YKeyStorage
 }
 
 // Transport is an implementation of http.RoundTripper that will return values from a cache

--- a/cache/types/souin.go
+++ b/cache/types/souin.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/darkweak/souin/cache/ykeys"
 	"github.com/darkweak/souin/configurationtypes"
 	"net/http"
 	"regexp"
@@ -28,6 +29,7 @@ type Transport struct {
 	MarkCachedResponses    bool
 	VaryLayerStorage       *VaryLayerStorage
 	CoalescingLayerStorage *CoalescingLayerStorage
+	YkeyStorage            *ykeys.YKeyStorage
 }
 
 // RetrieverResponsePropertiesInterface interface

--- a/cache/ykeys/ykey.go
+++ b/cache/ykeys/ykey.go
@@ -1,0 +1,134 @@
+package ykeys
+
+import (
+	"fmt"
+	"github.com/darkweak/souin/cache/keysaver"
+	"github.com/darkweak/souin/configurationtypes"
+	"github.com/dgraph-io/ristretto"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// The YKey system is like the Varnish one. You can invalidate cache from ykey based instead of the regexp or the plain
+// URL to invalidate. It will target the referred URLs to this tag
+// e.g.
+// Given YKey data as
+// |---------------|-----------------------------------------------------------------------------------|
+// | YKey          | URLs                                                                              |
+// |---------------|-----------------------------------------------------------------------------------|
+// | GROUP_KEY_ONE | http://domain.com/,http://domain.com/1,http://domain.com/2,http://domain.com/4    |
+// | GROUP_KEY_TWO | http://domain.com/1,http://domain.com/2,http://domain.com/3,http://domain.com/xyz |
+// |---------------|-----------------------------------------------------------------------------------|
+// When I send a purge request to /ykey/GROUP_KEY_ONE
+// Then the cache will be purged for the list
+// * http://domain.com/
+// * http://domain.com/1
+// * http://domain.com/2
+// * http://domain.com/4
+// And the data in the YKey table storage will contain
+// |---------------|-------------------------------------------|
+// | YKey          | URLs                                      |
+// |---------------|-------------------------------------------|
+// | GROUP_KEY_ONE |                                           |
+// | GROUP_KEY_TWO | http://domain.com/3,http://domain.com/xyz |
+// |---------------|-------------------------------------------|
+
+// YKeyStorage is the layer for YKey support storage
+type YKeyStorage struct {
+	*ristretto.Cache
+	keySaver *keysaver.ClearKey
+	Keys     map[string]configurationtypes.YKey
+}
+
+// InitializeYKeys will initialize the ykey storage system
+func InitializeYKeys(keys map[string]configurationtypes.YKey) *YKeyStorage {
+	storage, _ := ristretto.NewCache(&ristretto.Config{
+		NumCounters: 1e7,
+		MaxCost:     1 << 30,
+		BufferItems: 64,
+	})
+	keySaver := keysaver.NewClearKey()
+
+	for key, _ := range keys {
+		storage.Set(key, "", 1)
+		keySaver.AddKey(key)
+	}
+
+	return &YKeyStorage{Cache: storage, keySaver: keySaver, Keys: keys}
+}
+
+func (y *YKeyStorage) GetValidatedTags(key string, headers http.Header) []string {
+	var tags []string
+	for k, v := range y.Keys {
+		valid := true
+		if v.URL != "" {
+			if r, e := regexp.MatchString(v.URL, key); !r || e != nil {
+				valid = false
+				continue
+			}
+		}
+		if v.Headers != nil {
+			for h, hValue := range v.Headers {
+				if res, err := regexp.MatchString(hValue, headers.Get(h)); !res || err != nil {
+					valid = false
+					break
+				}
+			}
+		}
+		if valid {
+			tags = append(tags, k)
+		}
+	}
+
+	return tags
+}
+
+// InvalidateTags
+func (y *YKeyStorage) InvalidateTags(tags []string) []string {
+	var u []string
+	for _, tag := range tags {
+		if v, e := y.Cache.Get(tag); e {
+			u = append(u, y.InvalidateTagURLs(v.(string))...)
+		}
+	}
+
+	return u
+}
+
+func (y *YKeyStorage) InvalidateTagURLs(urls string) []string {
+	u := strings.Split(urls, ",")
+	for _, url := range u {
+		y.invalidateURL(url)
+	}
+	return u
+}
+
+func (y *YKeyStorage) invalidateURL(url string) {
+	urlRegexp := regexp.MustCompile(fmt.Sprintf("(%s,)|(,%s$)|(^%s$)", url, url, url))
+	for _, key := range y.keySaver.ListKeys() {
+		v, _ := y.Cache.Get(key)
+		if urlRegexp.MatchString(v.(string)) {
+			y.Set(key, urlRegexp.ReplaceAllString(v.(string), ""), 1)
+		}
+	}
+}
+
+func (y *YKeyStorage) AddToTags(url string, tags []string) {
+	for _, tag := range tags {
+		y.addToTag(url, tag)
+	}
+}
+
+func (y *YKeyStorage) addToTag(url string, tag string) {
+	if v, e := y.Cache.Get(tag); e {
+		urlRegexp := regexp.MustCompile(url)
+		tmpStr := v.(string)
+		if !urlRegexp.MatchString(tmpStr) {
+			if tmpStr != "" {
+				tmpStr += ","
+			}
+			y.Cache.Set(tag, tmpStr+url, 1)
+		}
+	}
+}

--- a/cache/ykeys/ykey_test.go
+++ b/cache/ykeys/ykey_test.go
@@ -1,0 +1,191 @@
+package ykeys
+
+import (
+	"fmt"
+	"github.com/darkweak/souin/configuration"
+	"github.com/darkweak/souin/configurationtypes"
+	"github.com/darkweak/souin/errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const FIRST_KEY = "The_First_Test"
+const SECOND_KEY = "The_Second_Test"
+const THIRD_KEY = "The_Third_Test"
+const FOURTH_KEY = "The_Fourth_Test"
+
+func mockYkeys() map[string]configurationtypes.YKey {
+	var config configuration.Configuration
+	_ = config.Parse([]byte(
+		`
+ykeys:
+  The_First_Test:
+    headers:
+      Authorization: '.+'
+      Content-Type: '.+'
+  The_Second_Test:
+    url: 'the/second/.+'
+  The_Third_Test:
+  The_Fourth_Test:
+`))
+	return config.Ykeys
+}
+
+func TestInitializeYKeys(t *testing.T) {
+	r := InitializeYKeys(mockYkeys())
+
+	if nil == r || nil == r.Cache {
+		errors.GenerateError(t, "Ristretto should be instanciated")
+	}
+
+	if nil == r || nil == r.keySaver {
+		errors.GenerateError(t, "The key saver should be instanciated")
+	}
+}
+
+func TestYKeyStorage_AddToTags(t *testing.T) {
+	baseYkeys := mockYkeys()
+	url := "http://the.url.com"
+
+	r := InitializeYKeys(baseYkeys)
+	r.AddToTags(url, []string{FIRST_KEY})
+	res, _ := r.Cache.Get(FIRST_KEY)
+	if !strings.Contains(res.(string), url) {
+		errors.GenerateError(t, fmt.Sprintf("R1 => The key %s should contains the url %s, %s given", FIRST_KEY, url, res))
+	}
+
+	r.AddToTags(url, []string{FIRST_KEY, SECOND_KEY})
+	r.AddToTags("http://domain.com", []string{FIRST_KEY})
+
+	res, _ = r.Cache.Get(FIRST_KEY)
+	if !strings.Contains(res.(string), url) {
+		errors.GenerateError(t, fmt.Sprintf("R2 => The key %s should contains the url %s, %s given", FIRST_KEY, url, res))
+	}
+	if len(strings.Split(res.(string), ",")) != 2 {
+		errors.GenerateError(t, fmt.Sprintf("R2 => The key %s should contains 2 records, %d given", FIRST_KEY, len(strings.Split(res.(string), ","))))
+	}
+
+	res, _ = r.Cache.Get(SECOND_KEY)
+	if !strings.Contains(res.(string), url) {
+		errors.GenerateError(t, fmt.Sprintf("R2 => The key %s should contains the url %s, %s given", SECOND_KEY, url, res))
+	}
+	if len(strings.Split(res.(string), ",")) != 1 {
+		errors.GenerateError(t, fmt.Sprintf("R2 => The key %s should contains 2 records, %d given", FIRST_KEY, len(strings.Split(res.(string), ","))))
+	}
+
+	r.AddToTags(url, []string{FIRST_KEY})
+	r.AddToTags(url, []string{FIRST_KEY})
+	r.AddToTags("http://domain.com", []string{FIRST_KEY})
+	res, _ = r.Cache.Get(FIRST_KEY)
+	if len(strings.Split(res.(string), ",")) != 2 {
+		errors.GenerateError(t, fmt.Sprintf("R3 => The key %s should contains 2 records, %d given", FIRST_KEY, len(strings.Split(res.(string), ","))))
+	}
+}
+
+func TestYKeyStorage_InvalidateTags(t *testing.T) {
+	baseYkeys := mockYkeys()
+	url1 := "http://the.url1.com"
+	url2 := "http://the.url2.com"
+	url3 := "http://the.url3.com"
+	url4 := "http://the.url4.com"
+
+	r := InitializeYKeys(baseYkeys)
+	r.AddToTags(url1, []string{FIRST_KEY, SECOND_KEY})
+	r.AddToTags(url2, []string{FIRST_KEY, SECOND_KEY})
+	r.AddToTags(url3, []string{FIRST_KEY, THIRD_KEY})
+	r.AddToTags(url4, []string{THIRD_KEY, FOURTH_KEY})
+
+	urls := r.InvalidateTags([]string{FIRST_KEY})
+
+	if len(urls) != 3 {
+		errors.GenerateError(t, "It should have 3 urls to remove (e.g. [http://the.url1.com http://the.url2.com http://the.url3.com])")
+	}
+
+	res, _ := r.Cache.Get(FIRST_KEY)
+	if res.(string) != "" {
+		errors.GenerateError(t, "The FIRST_KEY should be empty")
+	}
+
+	res, _ = r.Cache.Get(SECOND_KEY)
+	if res.(string) != "" {
+		errors.GenerateError(t, "The SECOND_KEY should be empty")
+	}
+
+	res, _ = r.Cache.Get(THIRD_KEY)
+	if res.(string) != url4 {
+		errors.GenerateError(t, "The THIRD_KEY should be equals to http://the.url4.com")
+	}
+
+	res, _ = r.Cache.Get(FOURTH_KEY)
+	if res.(string) != url4 {
+		errors.GenerateError(t, "The FOURTH_KEY should be equals to http://the.url4.com")
+	}
+}
+
+func TestYKeyStorage_InvalidateTagURLs(t *testing.T) {
+	baseYkeys := mockYkeys()
+	url1 := "http://the.url1.com"
+	url2 := "http://the.url2.com"
+	url3 := "http://the.url3.com"
+	url4 := "http://the.url4.com"
+
+	r := InitializeYKeys(baseYkeys)
+	r.AddToTags(url1, []string{FIRST_KEY, SECOND_KEY})
+	r.AddToTags(url2, []string{FIRST_KEY, SECOND_KEY})
+	r.AddToTags(url3, []string{FIRST_KEY, THIRD_KEY})
+	r.AddToTags(url4, []string{THIRD_KEY, FOURTH_KEY})
+
+	urls := r.InvalidateTagURLs(fmt.Sprintf("%s,%s", url1, url3))
+	if len(urls) != 2 {
+		errors.GenerateError(t, "It should have 2 urls to remove (e.g. [http://the.url1.com http://the.url3.com])")
+	}
+
+	res, _ := r.Cache.Get(FIRST_KEY)
+	if res.(string) != url2 {
+		errors.GenerateError(t, "The FIRST_KEY should be equals to http://the.url2.com")
+	}
+
+	res, _ = r.Cache.Get(SECOND_KEY)
+	if res.(string) != url2 {
+		errors.GenerateError(t, "The SECOND_KEY should be equals to http://the.url2.com")
+	}
+
+	res, _ = r.Cache.Get(THIRD_KEY)
+	if res.(string) != url4 {
+		errors.GenerateError(t, "The THIRD_KEY should be equals to http://the.url4.com")
+	}
+
+	res, _ = r.Cache.Get(FOURTH_KEY)
+	if res.(string) != url4 {
+		errors.GenerateError(t, "The FOURTH_KEY should be equals to http://the.url4.com")
+	}
+}
+
+func TestYKeyStorage_GetValidatedTags(t *testing.T) {
+	baseYkeys := mockYkeys()
+	r := InitializeYKeys(baseYkeys)
+	baseUrl := "http://the.url.com"
+	invalidUrl := "http://domain.com/test/the/second"
+	validUrl := invalidUrl + "/anything"
+	if len(r.GetValidatedTags(baseUrl, nil)) != 2 {
+		errors.GenerateError(t, fmt.Sprintf("The url %s without headers should be candidate for %v tags, %v given", baseUrl, []string{THIRD_KEY, FOURTH_KEY}, r.GetValidatedTags(baseUrl, nil)))
+	}
+	if len(r.GetValidatedTags(invalidUrl, nil)) != 2 {
+		errors.GenerateError(t, fmt.Sprintf("The url %s without headers should be candidate for %v tags, %v given", baseUrl, []string{THIRD_KEY, FOURTH_KEY}, r.GetValidatedTags(baseUrl, nil)))
+	}
+	if len(r.GetValidatedTags(validUrl, nil)) != 3 {
+		errors.GenerateError(t, fmt.Sprintf("The url %s without headers should be candidate for %v tags, %v given", baseUrl, []string{SECOND_KEY, THIRD_KEY, FOURTH_KEY}, r.GetValidatedTags(baseUrl, nil)))
+	}
+
+	var headers http.Header
+	headers = http.Header{}
+	headers.Set("Authorization", "anything")
+	headers.Set("Content-Type", "any value here")
+	if len(r.GetValidatedTags(baseUrl, headers)) != 3 {
+		errors.GenerateError(t, fmt.Sprintf("The url %s with headers %v should be candidate for %v tags, %v given", baseUrl, headers, []string{FIRST_KEY, THIRD_KEY, FOURTH_KEY}, r.GetValidatedTags(baseUrl, nil)))
+	}
+	if len(r.GetValidatedTags(validUrl, headers)) != 4 {
+		errors.GenerateError(t, fmt.Sprintf("The url %s with headers %v should be candidate for %v tags, %v given", baseUrl, headers, []string{FIRST_KEY, SECOND_KEY, THIRD_KEY, FOURTH_KEY}, r.GetValidatedTags(baseUrl, nil)))
+	}
+}

--- a/cache/ykeys/ykey_test.go
+++ b/cache/ykeys/ykey_test.go
@@ -50,6 +50,7 @@ func TestYKeyStorage_AddToTags(t *testing.T) {
 	url := "http://the.url.com"
 
 	r := InitializeYKeys(baseYkeys)
+	time.Sleep(200*time.Millisecond)
 	r.AddToTags(url, []string{FIRST_KEY})
 	time.Sleep(200*time.Millisecond)
 	res, _ := r.Cache.Get(FIRST_KEY)
@@ -96,6 +97,7 @@ func TestYKeyStorage_InvalidateTags(t *testing.T) {
 	url4 := "http://the.url4.com"
 
 	r := InitializeYKeys(baseYkeys)
+	time.Sleep(200*time.Millisecond)
 	r.AddToTags(url1, []string{FIRST_KEY, SECOND_KEY})
 	r.AddToTags(url2, []string{FIRST_KEY, SECOND_KEY})
 	r.AddToTags(url3, []string{FIRST_KEY, THIRD_KEY})
@@ -140,9 +142,13 @@ func TestYKeyStorage_InvalidateTagURLs(t *testing.T) {
 	url4 := "http://the.url4.com"
 
 	r := InitializeYKeys(baseYkeys)
+	time.Sleep(200*time.Millisecond)
 	r.AddToTags(url1, []string{FIRST_KEY, SECOND_KEY})
+	time.Sleep(200*time.Millisecond)
 	r.AddToTags(url2, []string{FIRST_KEY, SECOND_KEY})
+	time.Sleep(200*time.Millisecond)
 	r.AddToTags(url3, []string{FIRST_KEY, THIRD_KEY})
+	time.Sleep(200*time.Millisecond)
 	r.AddToTags(url4, []string{THIRD_KEY, FOURTH_KEY})
 
 	urls := r.InvalidateTagURLs(fmt.Sprintf("%s,%s", url1, url3))

--- a/cache/ykeys/ykey_test.go
+++ b/cache/ykeys/ykey_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 const FIRST_KEY = "The_First_Test"
@@ -50,6 +51,7 @@ func TestYKeyStorage_AddToTags(t *testing.T) {
 
 	r := InitializeYKeys(baseYkeys)
 	r.AddToTags(url, []string{FIRST_KEY})
+	time.Sleep(200*time.Millisecond)
 	res, _ := r.Cache.Get(FIRST_KEY)
 	if !strings.Contains(res.(string), url) {
 		errors.GenerateError(t, fmt.Sprintf("R1 => The key %s should contains the url %s, %s given", FIRST_KEY, url, res))
@@ -58,6 +60,7 @@ func TestYKeyStorage_AddToTags(t *testing.T) {
 	r.AddToTags(url, []string{FIRST_KEY, SECOND_KEY})
 	r.AddToTags("http://domain.com", []string{FIRST_KEY})
 
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(FIRST_KEY)
 	if !strings.Contains(res.(string), url) {
 		errors.GenerateError(t, fmt.Sprintf("R2 => The key %s should contains the url %s, %s given", FIRST_KEY, url, res))
@@ -66,6 +69,7 @@ func TestYKeyStorage_AddToTags(t *testing.T) {
 		errors.GenerateError(t, fmt.Sprintf("R2 => The key %s should contains 2 records, %d given", FIRST_KEY, len(strings.Split(res.(string), ","))))
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(SECOND_KEY)
 	if !strings.Contains(res.(string), url) {
 		errors.GenerateError(t, fmt.Sprintf("R2 => The key %s should contains the url %s, %s given", SECOND_KEY, url, res))
@@ -77,6 +81,7 @@ func TestYKeyStorage_AddToTags(t *testing.T) {
 	r.AddToTags(url, []string{FIRST_KEY})
 	r.AddToTags(url, []string{FIRST_KEY})
 	r.AddToTags("http://domain.com", []string{FIRST_KEY})
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(FIRST_KEY)
 	if len(strings.Split(res.(string), ",")) != 2 {
 		errors.GenerateError(t, fmt.Sprintf("R3 => The key %s should contains 2 records, %d given", FIRST_KEY, len(strings.Split(res.(string), ","))))
@@ -99,24 +104,28 @@ func TestYKeyStorage_InvalidateTags(t *testing.T) {
 	urls := r.InvalidateTags([]string{FIRST_KEY})
 
 	if len(urls) != 3 {
-		errors.GenerateError(t, "It should have 3 urls to remove (e.g. [http://the.url1.com http://the.url2.com http://the.url3.com])")
+		errors.GenerateError(t, fmt.Sprintf("It should have 3 urls to remove (e.g. [http://the.url1.com http://the.url2.com http://the.url3.com]), %v given", urls))
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ := r.Cache.Get(FIRST_KEY)
 	if res.(string) != "" {
 		errors.GenerateError(t, "The FIRST_KEY should be empty")
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(SECOND_KEY)
 	if res.(string) != "" {
 		errors.GenerateError(t, "The SECOND_KEY should be empty")
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(THIRD_KEY)
 	if res.(string) != url4 {
 		errors.GenerateError(t, "The THIRD_KEY should be equals to http://the.url4.com")
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(FOURTH_KEY)
 	if res.(string) != url4 {
 		errors.GenerateError(t, "The FOURTH_KEY should be equals to http://the.url4.com")
@@ -141,21 +150,25 @@ func TestYKeyStorage_InvalidateTagURLs(t *testing.T) {
 		errors.GenerateError(t, "It should have 2 urls to remove (e.g. [http://the.url1.com http://the.url3.com])")
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ := r.Cache.Get(FIRST_KEY)
 	if res.(string) != url2 {
 		errors.GenerateError(t, "The FIRST_KEY should be equals to http://the.url2.com")
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(SECOND_KEY)
 	if res.(string) != url2 {
 		errors.GenerateError(t, "The SECOND_KEY should be equals to http://the.url2.com")
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(THIRD_KEY)
 	if res.(string) != url4 {
 		errors.GenerateError(t, "The THIRD_KEY should be equals to http://the.url4.com")
 	}
 
+	time.Sleep(200*time.Millisecond)
 	res, _ = r.Cache.Get(FOURTH_KEY)
 	if res.(string) != url4 {
 		errors.GenerateError(t, "The FOURTH_KEY should be equals to http://the.url4.com")

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -10,13 +10,14 @@ import (
 
 //Configuration holder
 type Configuration struct {
-	DefaultCache    *configurationtypes.DefaultCache  `yaml:"default_cache"`
-	API             configurationtypes.API            `yaml:"api"`
-	ReverseProxyURL string                            `yaml:"reverse_proxy_url"`
-	SSLProviders    []string                          `yaml:"ssl_providers"`
-	URLs            map[string]configurationtypes.URL `yaml:"urls"`
-	LogLevel        string                            `yaml:"log_level"`
+	DefaultCache    *configurationtypes.DefaultCache   `yaml:"default_cache"`
+	API             configurationtypes.API             `yaml:"api"`
+	ReverseProxyURL string                             `yaml:"reverse_proxy_url"`
+	SSLProviders    []string                           `yaml:"ssl_providers"`
+	URLs            map[string]configurationtypes.URL  `yaml:"urls"`
+	LogLevel        string                             `yaml:"log_level"`
 	logger          *zap.Logger
+	Ykeys           map[string]configurationtypes.YKey `yaml:"ykeys"`
 }
 
 func readFile(path string) []byte {
@@ -73,6 +74,11 @@ func (c *Configuration) GetLogger() *zap.Logger {
 // SetLogger set the logger
 func (c *Configuration) SetLogger(l *zap.Logger) {
 	c.logger = l
+}
+
+// GetYkeys get the ykeys list
+func (c *Configuration) GetYkeys() map[string]configurationtypes.YKey {
+	return c.Ykeys
 }
 
 // GetConfiguration allow to retrieve Souin configuration through yaml file

--- a/configuration/configuration.yml
+++ b/configuration/configuration.yml
@@ -19,7 +19,7 @@ default_cache:
     exclude: 'ARegexHere'
   ttl: 10s
 log_level: debug
-reverse_proxy_url: 'http://traefik'
+reverse_proxy_url: 'http://domain.com:81'
 ssl_providers:
   - traefik
 urls:
@@ -32,3 +32,11 @@ urls:
     headers:
       - Authorization
       - 'Content-Type'
+ykeys:
+  The_First_Test:
+    headers:
+      Content-Type: '.+'
+  The_Second_Test:
+    url: 'the/second/.+'
+  The_Third_Test:
+  The_Fourth_Test:

--- a/configuration/configuration.yml
+++ b/configuration/configuration.yml
@@ -19,7 +19,7 @@ default_cache:
     exclude: 'ARegexHere'
   ttl: 10s
 log_level: debug
-reverse_proxy_url: 'http://domain.com:81'
+reverse_proxy_url: 'http://traefik'
 ssl_providers:
   - traefik
 urls:

--- a/configurationtypes/types.go
+++ b/configurationtypes/types.go
@@ -104,6 +104,11 @@ type API struct {
 	Security SecurityAPI `yaml:"security"`
 }
 
+type YKey struct {
+	URL     string            `yaml:"url"`
+	Headers map[string]string `yaml:"headers"`
+}
+
 // AbstractConfigurationInterface interface
 type AbstractConfigurationInterface interface {
 	GetUrls() map[string]URL
@@ -112,4 +117,5 @@ type AbstractConfigurationInterface interface {
 	GetLogLevel() string
 	GetLogger() *zap.Logger
 	SetLogger(*zap.Logger)
+	GetYkeys() map[string]YKey
 }

--- a/plugins/base.go
+++ b/plugins/base.go
@@ -4,6 +4,7 @@ import (
 	"github.com/darkweak/souin/cache/coalescing"
 	"github.com/darkweak/souin/cache/providers"
 	"github.com/darkweak/souin/cache/types"
+	"github.com/darkweak/souin/cache/ykeys"
 	"github.com/darkweak/souin/configurationtypes"
 	"github.com/darkweak/souin/helpers"
 	"github.com/darkweak/souin/rfc"
@@ -103,7 +104,7 @@ func DefaultSouinPluginInitializerFromConfiguration(c configurationtypes.Abstrac
 	c.GetLogger().Debug("Provider initialized")
 	regexpUrls := helpers.InitializeRegexp(c)
 	var transport types.TransportInterface
-	transport = rfc.NewTransport(provider)
+	transport = rfc.NewTransport(provider, ykeys.InitializeYKeys(c.GetYkeys()))
 	c.GetLogger().Debug("Transport initialized")
 
 	retriever := &types.RetrieverResponseProperties{

--- a/plugins/caddy/configuration.go
+++ b/plugins/caddy/configuration.go
@@ -46,6 +46,7 @@ type Configuration struct {
 	URLs         map[string]configurationtypes.URL
 	LogLevel     string
 	logger       *zap.Logger
+	Ykeys        map[string]configurationtypes.YKey
 }
 
 // GetUrls get the urls list in the configuration
@@ -76,4 +77,9 @@ func (c *Configuration) GetLogger() *zap.Logger {
 // SetLogger set the logger
 func (c *Configuration) SetLogger(l *zap.Logger) {
 	c.logger = l
+}
+
+// GetYkeys get the ykeys list
+func (c *Configuration) GetYkeys() map[string]configurationtypes.YKey {
+	return c.Ykeys
 }

--- a/plugins/caddy/main.go
+++ b/plugins/caddy/main.go
@@ -38,9 +38,10 @@ type SouinCaddyPlugin struct {
 	logger        *zap.Logger
 	LogLevel      string `json:"log_level,omitempty"`
 	bufPool       sync.Pool
-	Headers       []string `json:"headers,omitempty"`
-	Olric         configurationtypes.CacheProvider `json:"olric,omitempty"`
-	TTL           string `json:"ttl,omitempty"`
+	Headers       []string                           `json:"headers,omitempty"`
+	Olric         configurationtypes.CacheProvider   `json:"olric,omitempty"`
+	TTL           string                             `json:"ttl,omitempty"`
+	ykeys         map[string]configurationtypes.YKey `json:"ykeys,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
@@ -127,8 +128,8 @@ func (s *SouinCaddyPlugin) FromApp(app *SouinApp) error {
 
 	if s.Configuration.DefaultCache == nil {
 		s.Configuration.DefaultCache = &DefaultCache{
-			Headers:     app.Headers,
-			TTL:         app.TTL,
+			Headers: app.Headers,
+			TTL:     app.TTL,
 		}
 	} else {
 		dc := s.Configuration.DefaultCache

--- a/plugins/souin/main.go
+++ b/plugins/souin/main.go
@@ -72,7 +72,7 @@ func main() {
 	if basePathAPIS == "" {
 		basePathAPIS = "/souin-api"
 	}
-	for _, endpoint := range api.Initialize(retriever.Provider, c) {
+	for _, endpoint := range api.Initialize(retriever.Provider, c, retriever.GetTransport().GetYkeyStorage()) {
 		if endpoint.IsEnabled() {
 			c.GetLogger().Info(fmt.Sprintf("Enabling %s%s endpoint", basePathAPIS, endpoint.GetBasePath()))
 			http.HandleFunc(fmt.Sprintf("%s%s", basePathAPIS, endpoint.GetBasePath()), endpoint.HandleRequest)

--- a/plugins/traefik/configuration.go
+++ b/plugins/traefik/configuration.go
@@ -13,6 +13,7 @@ type Configuration struct {
 	URLs         map[string]configurationtypes.URL `yaml:"urls"`
 	LogLevel     string                            `yaml:"log_level"`
 	logger       *zap.Logger
+	Ykeys        map[string]configurationtypes.YKey `yaml:"ykeys"`
 }
 
 // Parse configuration
@@ -51,4 +52,9 @@ func (c *Configuration) GetLogger() *zap.Logger {
 // SetLogger set the logger
 func (c *Configuration) SetLogger(l *zap.Logger) {
 	c.logger = l
+}
+
+// GetYkeys get the ykeys list
+func (c *Configuration) GetYkeys() map[string]configurationtypes.YKey {
+	return c.Ykeys
 }

--- a/rfc/bridge_test.go
+++ b/rfc/bridge_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/darkweak/souin/cache/providers"
 	"github.com/darkweak/souin/cache/types"
+	"github.com/darkweak/souin/cache/ykeys"
 	"github.com/darkweak/souin/errors"
 	"github.com/darkweak/souin/tests"
 	"net/http"
@@ -11,18 +12,19 @@ import (
 	"testing"
 )
 
-func commonInitializer() (*http.Request, types.AbstractProviderInterface) {
+func commonInitializer() (*http.Request, types.AbstractProviderInterface, *VaryTransport) {
 	c := tests.MockConfiguration(tests.BaseConfiguration)
 	prs := providers.InitializeProvider(c)
 	r := httptest.NewRequest("GET", "http://domain.com/testing", nil)
 	httptest.NewRecorder()
 
-	return r, prs
+
+	return r, prs, NewTransport(prs, ykeys.InitializeYKeys(c.Ykeys))
 }
 
 func TestCachedResponse_WithUpdate(t *testing.T) {
-	r, c := commonInitializer()
-	res, err := CachedResponse(c, r, GetCacheKey(r), NewTransport(c), true)
+	r, c, v := commonInitializer()
+	res, err := CachedResponse(c, r, GetCacheKey(r), v, true)
 
 	if err != nil {
 		errors.GenerateError(t, "CachedResponse cannot throw error")
@@ -38,9 +40,9 @@ func TestCachedResponse_WithUpdate(t *testing.T) {
 }
 
 func TestCachedResponse_WithoutUpdate(t *testing.T) {
-	r, c := commonInitializer()
+	r, c, v := commonInitializer()
 	key := GetCacheKey(r)
-	res, err := CachedResponse(c, r, key, NewTransport(c), false)
+	res, err := CachedResponse(c, r, key, v, false)
 
 	if err != nil {
 		errors.GenerateError(t, "CachedResponse cannot throw error")

--- a/rfc/transport.go
+++ b/rfc/transport.go
@@ -51,6 +51,11 @@ func (t *VaryTransport) GetCoalescingLayerStorage() *types.CoalescingLayerStorag
 	return t.CoalescingLayerStorage
 }
 
+// GetYkeyStorage get the ykeys storage
+func (t *VaryTransport) GetYkeyStorage() *ykeys.YKeyStorage {
+	return t.YkeyStorage
+}
+
 // SetCache set the cache
 func (t *VaryTransport) SetCache(key string, resp *http.Response) {
 	if respBytes, err := httputil.DumpResponse(resp, true); err == nil {

--- a/rfc/vary_test.go
+++ b/rfc/vary_test.go
@@ -3,6 +3,7 @@ package rfc
 import (
 	"fmt"
 	"github.com/darkweak/souin/cache/providers"
+	"github.com/darkweak/souin/cache/ykeys"
 	"github.com/darkweak/souin/errors"
 	"github.com/darkweak/souin/tests"
 	"net/http/httptest"
@@ -12,7 +13,7 @@ import (
 func TestVaryMatches(t *testing.T) {
 	c := tests.MockConfiguration(tests.BaseConfiguration)
 	prs := providers.InitializeProvider(c)
-	tr := NewTransport(prs)
+	tr := NewTransport(prs, ykeys.InitializeYKeys(c.Ykeys))
 
 	r := httptest.NewRequest("GET", "http://domain.com/testing", nil)
 	res := httptest.NewRecorder().Result()

--- a/tests/mock.go
+++ b/tests/mock.go
@@ -52,6 +52,13 @@ urls:
     headers:
       - Authorization
       - 'Content-Type'
+ykeys:
+  The_First_Test:
+    headers:
+      Authorization: '.+'
+      Content-Type: '.+'
+  The_Second_Test:
+    url: 'the/second/.+'
 `
 }
 

--- a/tests/mock.go
+++ b/tests/mock.go
@@ -59,6 +59,7 @@ ykeys:
       Content-Type: '.+'
   The_Second_Test:
     url: 'the/second/.+'
+  The_Third_Test:
 `
 }
 


### PR DESCRIPTION
Implement YKey support to invalidate the cache using a `PURGE` request on the Souin API with the query parameter `ykey` and invalidate related urls that are part of the tagged key. It will remove the urls in other tags too.