### PR TITLE
Remove linux/riscv64 from BuildX CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           push: true
           file: ./Dockerfile-prod
-          platforms: linux/arm64,linux/amd64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/arm64,linux/amd64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7,linux/arm/v6
           tags: |
             darkweak/souin:latest
             darkweak/souin:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
alpine image is not compiled for this arch