### PR TITLE
Fix panic when parsing slice of string in Traefik plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,3 +509,4 @@ Thanks to these users for contributing or helping this project in any way
 * [Agneev](https://github.com/agneevX)
 * [Eidenschink](https://github.com/eidenschink/)
 * [Massimiliano Cannarozzo](https://github.com/maxcanna/)
+* [Kevin Pollet](https://github.com/kevinpollet)

--- a/plugins/traefik/base.go
+++ b/plugins/traefik/base.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/darkweak/souin/api"

--- a/plugins/traefik/main.go
+++ b/plugins/traefik/main.go
@@ -92,7 +92,7 @@ func parseConfiguration(c map[string]interface{}) Configuration {
 			for defaultCacheK, defaultCacheV := range defaultCache {
 				switch defaultCacheK {
 				case "headers":
-					dc.Headers = strings.Split(defaultCacheV.(string), ",")
+					dc.Headers = parseStringSlice(defaultCacheV)
 				case "regex":
 					exclude := defaultCacheV.(map[string]interface{})["exclude"].(string)
 					if exclude != "" {
@@ -125,7 +125,7 @@ func parseConfiguration(c map[string]interface{}) Configuration {
 					Headers: nil,
 				}
 				currentValue := urlV.(map[string]interface{})
-				currentURL.Headers = strings.Split(currentValue["headers"].(string), ",")
+				currentURL.Headers = parseStringSlice(currentValue["headers"])
 				d := currentValue["ttl"].(string)
 				ttl, err := time.ParseDuration(d)
 				if err == nil {
@@ -143,6 +143,20 @@ func parseConfiguration(c map[string]interface{}) Configuration {
 	}
 
 	return configuration
+}
+
+// parseStringSlice returns the string slice corresponding to the given interface.
+// The interface can be of type string which contains a comma separated list of values (e.g. foo,bar) or of type []string.
+func parseStringSlice(i interface{}) []string {
+	if value, ok := i.(string); ok {
+		return strings.Split(value, ",")
+	}
+
+	if value, ok := i.([]string); ok {
+		return value
+	}
+
+	return nil
 }
 
 // New create Souin instance.


### PR DESCRIPTION
## Motivation

Because the plugin configuration parsing is done differently in TraefikEE and Traefik Proxy, the configuration object given to the souin plugin is respectively different. This is why the code to parse this object was only working in the TraefikCE case.

Therefore, this pull request fixes the parsing in the souin plugin to work for both kinds of input.

Fixes #163   