### PR TITLE
Fixes  #169

### DIFF
--- a/plugins/traefik/vendor/github.com/darkweak/souin/rfc/bridge.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/rfc/bridge.go
@@ -133,7 +133,7 @@ func (t *VaryTransport) UpdateCacheEventually(req *http.Request) (*http.Response
 
 	req.Response = cachedResp
 
-	if cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(req.Response.Header)) {
+	if cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(req.Response.Header), req.Response.StatusCode) {
 		_ = validateVary(req, req.Response, cacheKey, t)
 	} else {
 		req.Response.Header.Set("Cache-Status", "Souin; fwd=uri-miss")
@@ -186,7 +186,7 @@ func (t *VaryTransport) RoundTrip(req *http.Request) (resp *http.Response, err e
 		resp.Header.Set("Cache-Status", "Souin; fwd=uri-miss")
 	}
 	resp, _ = transport.RoundTrip(req)
-	if !(cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(resp.Header)) && validateVary(req, resp, cacheKey, t)) {
+	if !(cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(resp.Header), req.Response.StatusCode) && validateVary(req, resp, cacheKey, t)) {
 		go func() {
 			t.Transport.CoalescingLayerStorage.Set(cacheKey)
 		}()

--- a/plugins/traefik/vendor/github.com/darkweak/souin/rfc/standalone.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/rfc/standalone.go
@@ -235,17 +235,7 @@ func canStore(reqCacheControl cacheControl, respCacheControl cacheControl, statu
 
 func cachableStatusCode(statusCode int) bool {
 	switch statusCode {
-		case 200: return true
-		case 203: return true
-		case 204: return true
-		case 206: return true
-		case 300: return true
-		case 301: return true
-		case 404: return true
-		case 405: return true
-		case 410: return true
-		case 414: return true
-		case 501: return true
+		case 200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501: return true
 		default: return false
 	}
 }

--- a/plugins/traefik/vendor/github.com/darkweak/souin/rfc/standalone.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/rfc/standalone.go
@@ -217,7 +217,11 @@ func getEndToEndHeaders(respHeaders http.Header) []string {
 	return endToEndHeaders
 }
 
-func canStore(reqCacheControl, respCacheControl cacheControl) (canStore bool) {
+func canStore(reqCacheControl cacheControl, respCacheControl cacheControl, status int) (canStore bool) {
+	if !cachableStatusCode(status){
+		return false
+	}
+
 	for _, t := range []string{"no-cache", "no-store"} {
 		if _, ok := respCacheControl[t]; ok {
 			return false
@@ -227,6 +231,23 @@ func canStore(reqCacheControl, respCacheControl cacheControl) (canStore bool) {
 		}
 	}
 	return true
+}
+
+func cachableStatusCode(statusCode int) bool {
+	switch statusCode {
+		case 200: return true
+		case 203: return true
+		case 204: return true
+		case 206: return true
+		case 300: return true
+		case 301: return true
+		case 404: return true
+		case 405: return true
+		case 410: return true
+		case 414: return true
+		case 501: return true
+		default: return false
+	}
 }
 
 func newGatewayTimeoutResponse(req *http.Request) *http.Response {

--- a/rfc/bridge.go
+++ b/rfc/bridge.go
@@ -133,7 +133,7 @@ func (t *VaryTransport) UpdateCacheEventually(req *http.Request) (*http.Response
 
 	req.Response = cachedResp
 
-	if cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(req.Response.Header)) {
+	if cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(req.Response.Header), req.Response.StatusCode) {
 		_ = validateVary(req, req.Response, cacheKey, t)
 	} else {
 		req.Response.Header.Set("Cache-Status", "Souin; fwd=uri-miss")
@@ -186,7 +186,7 @@ func (t *VaryTransport) RoundTrip(req *http.Request) (resp *http.Response, err e
 		resp.Header.Set("Cache-Status", "Souin; fwd=uri-miss")
 	}
 	resp, _ = transport.RoundTrip(req)
-	if !(cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(resp.Header)) && validateVary(req, resp, cacheKey, t)) {
+	if !(cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(resp.Header), req.Response.StatusCode) && validateVary(req, resp, cacheKey, t)) {
 		go func() {
 			t.Transport.CoalescingLayerStorage.Set(cacheKey)
 		}()

--- a/rfc/standalone.go
+++ b/rfc/standalone.go
@@ -235,17 +235,7 @@ func canStore(reqCacheControl cacheControl, respCacheControl cacheControl, statu
 
 func cachableStatusCode(statusCode int) bool {
 	switch statusCode {
-		case 200: return true
-		case 203: return true
-		case 204: return true
-		case 206: return true
-		case 300: return true
-		case 301: return true
-		case 404: return true
-		case 405: return true
-		case 410: return true
-		case 414: return true
-		case 501: return true
+		case 200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501: return true
 		default: return false
 	}
 }

--- a/rfc/standalone.go
+++ b/rfc/standalone.go
@@ -217,7 +217,11 @@ func getEndToEndHeaders(respHeaders http.Header) []string {
 	return endToEndHeaders
 }
 
-func canStore(reqCacheControl, respCacheControl cacheControl) (canStore bool) {
+func canStore(reqCacheControl cacheControl, respCacheControl cacheControl, status int) (canStore bool) {
+	if !cachableStatusCode(status){
+		return false
+	}
+
 	for _, t := range []string{"no-cache", "no-store"} {
 		if _, ok := respCacheControl[t]; ok {
 			return false
@@ -227,6 +231,23 @@ func canStore(reqCacheControl, respCacheControl cacheControl) (canStore bool) {
 		}
 	}
 	return true
+}
+
+func cachableStatusCode(statusCode int) bool {
+	switch statusCode {
+		case 200: return true
+		case 203: return true
+		case 204: return true
+		case 206: return true
+		case 300: return true
+		case 301: return true
+		case 404: return true
+		case 405: return true
+		case 410: return true
+		case 414: return true
+		case 501: return true
+		default: return false
+	}
 }
 
 func newGatewayTimeoutResponse(req *http.Request) *http.Response {

--- a/rfc/standalone_test.go
+++ b/rfc/standalone_test.go
@@ -54,20 +54,43 @@ func TestCanStore(t *testing.T) {
 	resCacheControl := make(map[string]string)
 	reqCacheControl := make(map[string]string)
 
-	if !canStore(reqCacheControl, resCacheControl) {
+	if !canStore(reqCacheControl, resCacheControl, 200) {
 		errors.GenerateError(t, "Res and Req doesn't contains headers, it should return true")
+	}
+
+	if canStore(reqCacheControl, resCacheControl, 502) {
+		errors.GenerateError(t, "Status code shouldnt be stored, it should return false")
 	}
 
 	reqCacheControl["no-store"] = "any"
 
-	if canStore(reqCacheControl, resCacheControl) {
+	if canStore(reqCacheControl, resCacheControl, 200) {
 		errors.GenerateError(t, "Req contains headers, it should return false")
 	}
 
 	resCacheControl["no-store"] = "any"
 
-	if canStore(reqCacheControl, resCacheControl) {
+	if canStore(reqCacheControl, resCacheControl, 200) {
 		errors.GenerateError(t, "Res contains headers, it should return false")
+	}
+}
+
+func TestcachableStatusCode(t *testing.T) {
+	cachable := map[int]bool{
+		200: true,
+		300: true,
+		301: true,
+		404: true,
+		500: false,
+		502: false,
+	}
+
+	for key, value := range cachable {
+		res := cachableStatusCode(key)
+		if (res != value) {
+			msg := fmt.Sprintf("Unexpected response for statusCode %d: %t (expected: %t)", key, res, value)
+			errors.GenerateError(t, msg)
+		}
 	}
 }
 


### PR DESCRIPTION
Should fix #169 by adding a check for status code in the `canStore` function of `rfc/standalone.go`

Note: If this feature not necessarily desired, one could add a parameter to the configuration file to disable it