### PR TITLE
fix(test): standalone_test.go

### DIFF
--- a/rfc/standalone_test.go
+++ b/rfc/standalone_test.go
@@ -75,7 +75,7 @@ func TestCanStore(t *testing.T) {
 	}
 }
 
-func TestcachableStatusCode(t *testing.T) {
+func TestCachableStatusCode(t *testing.T) {
 	cachable := map[int]bool{
 		200: true,
 		300: true,


### PR DESCRIPTION
Lower case character lead to CI/CD failing