### PR TITLE
feat(core): specify default Cache-Control for responses when not set …

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ reverse_proxy_url: 'http://traefik' # If it's in the same network you can use ht
 | `default_cache.ttl` | Duration to cache request (in seconds)                      | 10                                                                                                                        |
 | `reverse_proxy_url` | The reverse-proxy's instance URL (Apache, Nginx, Træfik...) | - `http://yourservice` (Container way)<br/>`http://localhost:81` (Local way)<br/>`http://yourdomain.com:81` (Network way) |
 
+Besides, it's highly recommended to set `default_cache.default_cache_control` (see it below) to avoid undesired caching for responses without `Cache-Control` header.
+
 ### Optional configuration
 ```yaml
 # /anywhere/configuration.yml
@@ -94,6 +96,7 @@ default_cache:
     exclude: 'ARegexHere' # Regex to exclude from cache
   stale: 1000s # Stale duration
   ttl: 1000s # Default TTL
+  default_cache_control: no-store # Set default value for Cache-Control response header if not set by upstream
 log_level: INFO # Logs verbosity [ DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL ], case do not matter
 ssl_providers: # The {providers}.json to use
   - traefik
@@ -109,6 +112,7 @@ urls:
     headers: # Override default headers
     - Authorization
     - 'Content-Type'
+    default_cache_control: public, max-age=86400 # Override default default Cache-Control
 ykeys:
   The_First_Test:
     headers:
@@ -157,10 +161,12 @@ surrogate_keys:
 | `default_cache.regex.exclude`                     | The regex used to prevent paths being cached                                                   | `^[A-z]+.*$`                                                                                                            |
 | `default_cache.stale`                             | The stale duration                                                                             | `25m`                                                                                                                   |
 | `default_cache.ttl`                               | The TTL duration                                                                               | `120s`                                                                                                                  |
+| `default_cache.default_cache_control`             | Set the default value of `Cache-Control` response header if not set by upstream (Souin treats empty `Cache-Control` as `public` if omitted) | `no-store`                                                                                                                  |
 | `log_level`                                       | The log level                                                                                  | `One of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL it's case insensitive`                                           |
 | `ssl_providers`                                   | List of your providers handling certificates                                                   | `- traefik`<br/><br/>`- nginx`<br/><br/>`- apache`                                                                      |
 | `urls.{your url or regex}`                        | List of your custom configuration depending each URL or regex                                  | 'https:\/\/yourdomain.com'                                                                                              |
 | `urls.{your url or regex}.ttl`                    | Override the default TTL if defined                                                            | `90s`<br/><br/>`10m`                                                                                                    |
+| `urls.{your url or regex}.default_cache_control`  | Override the default default `Cache-Control` if defined                                                            | `public, max-age=86400`                                                                                                    |
 | `urls.{your url or regex}.headers`                | Override the default headers if defined                                                        | `- Authorization`<br/><br/>`- 'Content-Type'`                                                                           |
 | `surrogate_keys.{key name}.headers`               | Headers that should match to be part of the surrogate key group                                | `Authorization: ey.+`<br/><br/>`Content-Type: json`                                                                     |
 | `surrogate_keys.{key name}.headers.{header name}` | Header name that should be present a match the regex to be part of the surrogate key group     | `Content-Type: json`                                                                                                    |
@@ -341,6 +347,7 @@ There is the fully configuration below
         }
         stale 200s
         ttl 1000s
+        default_cache_control no-store
     }
 }
 
@@ -359,6 +366,7 @@ cache @match {
 cache @match2 {
     ttl 50s
     headers Authorization
+    default_cache_control "public, max-age=86400"
 }
 
 cache @matchdefault {
@@ -476,6 +484,7 @@ http:
             regex:
               exclude: '/test_exclude.*'
             ttl: 5s
+            default_cache_control: no-store
           log_level: debug
           urls:
             'domain.com/testing':
@@ -487,6 +496,7 @@ http:
               headers:
                 - Authorization
                 - 'Content-Type'
+              default_cache_control: public, max-age=86400
           ykeys:
             The_First_Test:
               headers:
@@ -578,7 +588,8 @@ You have to define the use of Souin as `post` and `response` custom middleware. 
       }
     },
     "default_cache": {
-      "ttl": "5s"
+      "ttl": "5s",
+      "default_cache_control": "no-store"
     }
   }
 }

--- a/cache/types/souin.go
+++ b/cache/types/souin.go
@@ -84,8 +84,9 @@ func (r *RetrieverResponseProperties) SetMatchedURLFromRequest(req *http.Request
 	path := req.Host + req.URL.Path
 	regexpURL := r.GetRegexpUrls().FindString(path)
 	url := configurationtypes.URL{
-		TTL:     configurationtypes.Duration{Duration: r.GetConfiguration().GetDefaultCache().GetTTL()},
-		Headers: r.GetConfiguration().GetDefaultCache().GetHeaders(),
+		TTL:                 configurationtypes.Duration{Duration: r.GetConfiguration().GetDefaultCache().GetTTL()},
+		Headers:             r.GetConfiguration().GetDefaultCache().GetHeaders(),
+		DefaultCacheControl: r.GetConfiguration().GetDefaultCache().GetDefaultCacheControl(),
 	}
 	if regexpURL != "" {
 		u := r.GetConfiguration().GetUrls()[regexpURL]

--- a/configurationtypes/types.go
+++ b/configurationtypes/types.go
@@ -57,8 +57,9 @@ type Regex struct {
 
 // URL configuration
 type URL struct {
-	TTL     Duration `json:"ttl" yaml:"ttl"`
-	Headers []string `json:"headers" yaml:"headers"`
+	TTL                 Duration `json:"ttl" yaml:"ttl"`
+	Headers             []string `json:"headers" yaml:"headers"`
+	DefaultCacheControl string   `json:"default_cache_control" yaml:"default_cache_control"`
 }
 
 // CacheProvider config
@@ -83,15 +84,16 @@ type CDN struct {
 
 // DefaultCache configuration
 type DefaultCache struct {
-	Badger      CacheProvider `json:"badger" yaml:"badger"`
-	CDN         CDN           `json:"cdn" yaml:"cdn"`
-	Distributed bool          `json:"distributed" yaml:"distributed"`
-	Headers     []string      `json:"headers" yaml:"headers"`
-	Olric       CacheProvider `json:"olric" yaml:"olric"`
-	Port        Port          `json:"port" yaml:"port"`
-	Regex       Regex         `json:"regex" yaml:"regex"`
-	TTL         Duration      `json:"ttl" yaml:"ttl"`
-	Stale       Duration      `json:"stale" yaml:"stale"`
+	Badger              CacheProvider `json:"badger" yaml:"badger"`
+	CDN                 CDN           `json:"cdn" yaml:"cdn"`
+	Distributed         bool          `json:"distributed" yaml:"distributed"`
+	Headers             []string      `json:"headers" yaml:"headers"`
+	Olric               CacheProvider `json:"olric" yaml:"olric"`
+	Port                Port          `json:"port" yaml:"port"`
+	Regex               Regex         `json:"regex" yaml:"regex"`
+	TTL                 Duration      `json:"ttl" yaml:"ttl"`
+	Stale               Duration      `json:"stale" yaml:"stale"`
+	DefaultCacheControl string        `json:"default_cache_control" yaml:"default_cache_control"`
 }
 
 // GetBadger returns the Badger configuration
@@ -134,6 +136,11 @@ func (d *DefaultCache) GetStale() time.Duration {
 	return d.Stale.Duration
 }
 
+// GetDefaultCacheControl returns the default Cache-Control response header value when empty
+func (d *DefaultCache) GetDefaultCacheControl() string {
+	return d.DefaultCacheControl
+}
+
 // DefaultCacheInterface interface
 type DefaultCacheInterface interface {
 	GetBadger() CacheProvider
@@ -144,6 +151,7 @@ type DefaultCacheInterface interface {
 	GetRegex() Regex
 	GetTTL() time.Duration
 	GetStale() time.Duration
+	GetDefaultCacheControl() string
 }
 
 // APIEndpoint is the minimal structure to define an endpoint

--- a/plugins/base.go
+++ b/plugins/base.go
@@ -208,8 +208,9 @@ func DefaultSouinPluginInitializerFromConfiguration(c configurationtypes.Abstrac
 
 	retriever := &types.RetrieverResponseProperties{
 		MatchedURL: configurationtypes.URL{
-			TTL:     configurationtypes.Duration{Duration: c.GetDefaultCache().GetTTL()},
-			Headers: c.GetDefaultCache().GetHeaders(),
+			TTL:                 configurationtypes.Duration{Duration: c.GetDefaultCache().GetTTL()},
+			Headers:             c.GetDefaultCache().GetHeaders(),
+			DefaultCacheControl: c.GetDefaultCache().GetDefaultCacheControl(),
 		},
 		Provider:      provider,
 		Configuration: c,

--- a/plugins/caddy/Caddyfile
+++ b/plugins/caddy/Caddyfile
@@ -18,6 +18,7 @@
         headers Content-Type Authorization
         log_level debug
         ttl 1000s
+        default_cache_control no-store
     }
 }
 
@@ -36,6 +37,7 @@ cache @match {
 cache @match2 {
     ttl 50s
     headers Authorization
+    default_cache_control "public, max-age=86400"
 }
 
 cache @matchdefault {

--- a/plugins/caddy/README.md
+++ b/plugins/caddy/README.md
@@ -58,6 +58,7 @@ There is the fully configuration below
         }
         stale 200s
         ttl 1000s
+        default_cache_control no-store
     }
 }
 
@@ -76,6 +77,7 @@ cache @match {
 cache @match2 {
     ttl 50s
     headers Authorization
+    default_cache_control "public, max-age=86400"
 }
 
 cache @matchdefault {

--- a/plugins/caddy/configuration.go
+++ b/plugins/caddy/configuration.go
@@ -9,14 +9,15 @@ import (
 
 // DefaultCache the struct
 type DefaultCache struct {
-	Badger      configurationtypes.CacheProvider
-	CDN         configurationtypes.CDN
-	Distributed bool
-	Headers     []string
-	Olric       configurationtypes.CacheProvider
-	Regex       configurationtypes.Regex
-	TTL         configurationtypes.Duration
-	Stale       configurationtypes.Duration
+	Badger              configurationtypes.CacheProvider
+	CDN                 configurationtypes.CDN
+	Distributed         bool
+	Headers             []string
+	Olric               configurationtypes.CacheProvider
+	Regex               configurationtypes.Regex
+	TTL                 configurationtypes.Duration
+	Stale               configurationtypes.Duration
+	DefaultCacheControl string
 }
 
 // GetBadger returns the Badger configuration
@@ -57,6 +58,11 @@ func (d *DefaultCache) GetTTL() time.Duration {
 // GetStale returns the stale duration
 func (d *DefaultCache) GetStale() time.Duration {
 	return d.Stale.Duration
+}
+
+// GetStale returns the stale duration
+func (d *DefaultCache) GetDefaultCacheControl() string {
+	return d.DefaultCacheControl
 }
 
 //Configuration holder

--- a/plugins/caddy/examples/Caddyfile-embedded-olric
+++ b/plugins/caddy/examples/Caddyfile-embedded-olric
@@ -7,6 +7,7 @@
             path path/to/olric.yml
         }
         ttl 1000s
+        default_cache_control no-store
     }
 }
 
@@ -24,6 +25,7 @@ cache @match {
 cache @match2 {
     ttl 50s
     headers Authorization
+    default_cache_control "public, max-age=86400"
 }
 
 cache @matchdefault {

--- a/plugins/caddy/examples/Caddyfile-file-configuration-olric
+++ b/plugins/caddy/examples/Caddyfile-file-configuration-olric
@@ -7,6 +7,7 @@
             path path/to/olric.yml
         }
         ttl 1000s
+        default_cache_control no-store
     }
 }
 
@@ -24,6 +25,7 @@ cache @match {
 cache @match2 {
     ttl 50s
     headers Authorization
+    default_cache_control "public, max-age=86400"
 }
 
 cache @matchdefault {

--- a/plugins/caddy/examples/Caddyfile-not-distributed
+++ b/plugins/caddy/examples/Caddyfile-not-distributed
@@ -4,6 +4,7 @@
         headers Content-Type Authorization
         log_level info
         ttl 1000s
+        default_cache_control no-store
     }
 }
 
@@ -21,6 +22,7 @@ cache @match {
 cache @match2 {
     ttl 50s
     headers Authorization
+    default_cache_control "public, max-age=86400"
 }
 
 cache @matchdefault {

--- a/plugins/caddy/examples/Caddyfile-remote-olric-cluster
+++ b/plugins/caddy/examples/Caddyfile-remote-olric-cluster
@@ -7,6 +7,7 @@
             url olric:3320
         }
         ttl 1000s
+        default_cache_control no-store
     }
 }
 
@@ -24,6 +25,7 @@ cache @match {
 cache @match2 {
     ttl 50s
     headers Authorization
+    default_cache_control "public, max-age=86400"
 }
 
 cache @matchdefault {

--- a/plugins/caddy/examples/configuration-embedded-olric.json
+++ b/plugins/caddy/examples/configuration-embedded-olric.json
@@ -9,7 +9,8 @@
       "olric": {
         "path": "path/to/olric.yml"
       },
-      "ttl": "1000s"
+      "ttl": "1000s",
+      "default_cache_control": "no-store"
     },
     "http": {
       "servers": {
@@ -30,7 +31,8 @@
               "handle": [
                 {
                   "handler": "cache",
-                  "ttl": "30s"
+                  "ttl": "30s",
+                  "default_cache_control": "public, max-age=86400"
                 }
               ]
             },

--- a/plugins/caddy/examples/configuration-file-configuration-olric.json
+++ b/plugins/caddy/examples/configuration-file-configuration-olric.json
@@ -9,7 +9,8 @@
       "olric": {
         "path": "path/to/olric.yml"
       },
-      "ttl": "1000s"
+      "ttl": "1000s",
+      "default_cache_control": "no-store"
     },
     "http": {
       "servers": {
@@ -30,7 +31,8 @@
               "handle": [
                 {
                   "handler": "cache",
-                  "ttl": "30s"
+                  "ttl": "30s",
+                  "default_cache_control": "public, max-age=86400"
                 }
               ]
             },

--- a/plugins/caddy/examples/configuration-not-distributed.json
+++ b/plugins/caddy/examples/configuration-not-distributed.json
@@ -6,7 +6,8 @@
         "Authorization"
       ],
       "log_level": "info",
-      "ttl": "1000s"
+      "ttl": "1000s",
+      "default_cache_control": "no-store"
     },
     "http": {
       "servers": {
@@ -27,7 +28,8 @@
               "handle": [
                 {
                   "handler": "cache",
-                  "ttl": "30s"
+                  "ttl": "30s",
+                  "default_cache_control": "public, max-age=86400"
                 }
               ]
             },

--- a/plugins/caddy/examples/configuration-remote-olric-cluster.json
+++ b/plugins/caddy/examples/configuration-remote-olric-cluster.json
@@ -9,7 +9,8 @@
       "olric": {
         "url": "olric:3320"
       },
-      "ttl": "1000s"
+      "ttl": "1000s",
+      "default_cache_control": "no-store"
     },
     "http": {
       "servers": {
@@ -30,7 +31,8 @@
               "handle": [
                 {
                   "handler": "cache",
-                  "ttl": "30s"
+                  "ttl": "30s",
+                  "default_cache_control": "public, max-age=86400"
                 }
               ]
             },

--- a/plugins/traefik/main.go
+++ b/plugins/traefik/main.go
@@ -100,8 +100,9 @@ func parseConfiguration(c map[string]interface{}) Configuration {
 					Path:          "",
 					Configuration: nil,
 				},
-				Regex: configurationtypes.Regex{},
-				TTL:   configurationtypes.Duration{},
+				Regex:               configurationtypes.Regex{},
+				TTL:                 configurationtypes.Duration{},
+				DefaultCacheControl: "",
 			}
 			defaultCache := v.(map[string]interface{})
 			for defaultCacheK, defaultCacheV := range defaultCache {
@@ -123,6 +124,8 @@ func parseConfiguration(c map[string]interface{}) Configuration {
 					if err == nil {
 						dc.Stale = configurationtypes.Duration{Duration: stale}
 					}
+				case "default_cache_control":
+					dc.DefaultCacheControl = defaultCacheV.(string)
 				}
 			}
 			configuration.DefaultCache = &dc
@@ -146,6 +149,7 @@ func parseConfiguration(c map[string]interface{}) Configuration {
 				if err == nil {
 					currentURL.TTL = configurationtypes.Duration{Duration: ttl}
 				}
+				currentURL.DefaultCacheControl = currentValue["default_cache_control"].(string)
 				u[urlK] = currentURL
 			}
 			configuration.URLs = u

--- a/plugins/traefik/souin-configuration.yaml
+++ b/plugins/traefik/souin-configuration.yaml
@@ -31,6 +31,7 @@ http:
             regex:
               exclude: '/test_exclude.*'
             ttl: 5s
+            default_cache_control: no-store
           log_level: debug
           urls:
             'domain.com/testing':
@@ -42,6 +43,7 @@ http:
               headers:
                 - Authorization
                 - 'Content-Type'
+              default_cache_control: public, max-age=86400
           ykeys:
             The_First_Test:
               headers:

--- a/plugins/traefik/vendor/github.com/darkweak/souin/cache/types/souin.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/cache/types/souin.go
@@ -84,8 +84,9 @@ func (r *RetrieverResponseProperties) SetMatchedURLFromRequest(req *http.Request
 	path := req.Host + req.URL.Path
 	regexpURL := r.GetRegexpUrls().FindString(path)
 	url := configurationtypes.URL{
-		TTL:     configurationtypes.Duration{Duration: r.GetConfiguration().GetDefaultCache().GetTTL()},
-		Headers: r.GetConfiguration().GetDefaultCache().GetHeaders(),
+		TTL:                 configurationtypes.Duration{Duration: r.GetConfiguration().GetDefaultCache().GetTTL()},
+		Headers:             r.GetConfiguration().GetDefaultCache().GetHeaders(),
+		DefaultCacheControl: r.GetConfiguration().GetDefaultCache().GetDefaultCacheControl(),
 	}
 	if regexpURL != "" {
 		u := r.GetConfiguration().GetUrls()[regexpURL]

--- a/plugins/traefik/vendor/github.com/darkweak/souin/configurationtypes/types.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/configurationtypes/types.go
@@ -57,8 +57,9 @@ type Regex struct {
 
 // URL configuration
 type URL struct {
-	TTL     Duration `json:"ttl" yaml:"ttl"`
-	Headers []string `json:"headers" yaml:"headers"`
+	TTL                 Duration `json:"ttl" yaml:"ttl"`
+	Headers             []string `json:"headers" yaml:"headers"`
+	DefaultCacheControl string   `json:"default_cache_control" yaml:"default_cache_control"`
 }
 
 // CacheProvider config
@@ -83,15 +84,16 @@ type CDN struct {
 
 // DefaultCache configuration
 type DefaultCache struct {
-	Badger      CacheProvider `json:"badger" yaml:"badger"`
-	CDN         CDN           `json:"cdn" yaml:"cdn"`
-	Distributed bool          `json:"distributed" yaml:"distributed"`
-	Headers     []string      `json:"headers" yaml:"headers"`
-	Olric       CacheProvider `json:"olric" yaml:"olric"`
-	Port        Port          `json:"port" yaml:"port"`
-	Regex       Regex         `json:"regex" yaml:"regex"`
-	TTL         Duration      `json:"ttl" yaml:"ttl"`
-	Stale       Duration      `json:"stale" yaml:"stale"`
+	Badger              CacheProvider `json:"badger" yaml:"badger"`
+	CDN                 CDN           `json:"cdn" yaml:"cdn"`
+	Distributed         bool          `json:"distributed" yaml:"distributed"`
+	Headers             []string      `json:"headers" yaml:"headers"`
+	Olric               CacheProvider `json:"olric" yaml:"olric"`
+	Port                Port          `json:"port" yaml:"port"`
+	Regex               Regex         `json:"regex" yaml:"regex"`
+	TTL                 Duration      `json:"ttl" yaml:"ttl"`
+	Stale               Duration      `json:"stale" yaml:"stale"`
+	DefaultCacheControl string        `json:"default_cache_control" yaml:"default_cache_control"`
 }
 
 // GetBadger returns the Badger configuration
@@ -134,6 +136,11 @@ func (d *DefaultCache) GetStale() time.Duration {
 	return d.Stale.Duration
 }
 
+// GetDefaultCacheControl returns the default Cache-Control response header value when empty
+func (d *DefaultCache) GetDefaultCacheControl() string {
+	return d.DefaultCacheControl
+}
+
 // DefaultCacheInterface interface
 type DefaultCacheInterface interface {
 	GetBadger() CacheProvider
@@ -144,6 +151,7 @@ type DefaultCacheInterface interface {
 	GetRegex() Regex
 	GetTTL() time.Duration
 	GetStale() time.Duration
+	GetDefaultCacheControl() string
 }
 
 // APIEndpoint is the minimal structure to define an endpoint

--- a/plugins/traefik/vendor/github.com/darkweak/souin/rfc/bridge.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/rfc/bridge.go
@@ -120,6 +120,11 @@ func commonVaryMatchesVerification(cachedResp *http.Response, req *http.Request)
 
 // UpdateCacheEventually will handle Request and update the previous one in the cache provider
 func (t *VaryTransport) UpdateCacheEventually(req *http.Request) (*http.Response, error) {
+	defaultCacheControl := t.ConfigurationURL.DefaultCacheControl
+	if req.Response.Header.Get("Cache-Control") == "" && defaultCacheControl != "" {
+		req.Response.Header.Set("Cache-Control", t.ConfigurationURL.DefaultCacheControl)
+	}
+
 	cacheKey, cacheable, cachedResp := t.BaseRoundTrip(req, false)
 
 	if cacheable && cachedResp != nil {

--- a/plugins/tyk/configuration.go
+++ b/plugins/tyk/configuration.go
@@ -35,14 +35,15 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 // DefaultCache the struct
 type DefaultCache struct {
-	Badger      configurationtypes.CacheProvider `json:"badger,omitempty"`
-	CDN         configurationtypes.CDN           `json:"cdn,omitempty"`
-	Distributed bool
-	Headers     []string                         `json:"api,omitempty"`
-	Olric       configurationtypes.CacheProvider `json:"olric,omitempty"`
-	Regex       configurationtypes.Regex         `json:"regex,omitempty"`
-	TTL         Duration                         `json:"ttl,omitempty"`
-	Stale       configurationtypes.Duration      `json:"stale,omitempty"`
+	Badger              configurationtypes.CacheProvider `json:"badger,omitempty"`
+	CDN                 configurationtypes.CDN           `json:"cdn,omitempty"`
+	Distributed         bool
+	Headers             []string                         `json:"api,omitempty"`
+	Olric               configurationtypes.CacheProvider `json:"olric,omitempty"`
+	Regex               configurationtypes.Regex         `json:"regex,omitempty"`
+	TTL                 Duration                         `json:"ttl,omitempty"`
+	Stale               configurationtypes.Duration      `json:"stale,omitempty"`
+	DefaultCacheControl string                           `json:"default_cache_control,omitempty"`
 }
 
 // GetBadger returns the Badger configuration
@@ -83,6 +84,11 @@ func (d *DefaultCache) GetTTL() time.Duration {
 // GetStale returns the stale duration
 func (d *DefaultCache) GetStale() time.Duration {
 	return d.Stale.Duration
+}
+
+// GetDefaultCacheControl returns the default Cache-Control response header value when empty
+func (d *DefaultCache) GetDefaultCacheControl() string {
+	return d.DefaultCacheControl
 }
 
 //Configuration holder

--- a/rfc/bridge.go
+++ b/rfc/bridge.go
@@ -120,6 +120,11 @@ func commonVaryMatchesVerification(cachedResp *http.Response, req *http.Request)
 
 // UpdateCacheEventually will handle Request and update the previous one in the cache provider
 func (t *VaryTransport) UpdateCacheEventually(req *http.Request) (*http.Response, error) {
+	defaultCacheControl := t.ConfigurationURL.DefaultCacheControl
+	if req.Response.Header.Get("Cache-Control") == "" && defaultCacheControl != "" {
+		req.Response.Header.Set("Cache-Control", t.ConfigurationURL.DefaultCacheControl)
+	}
+
 	cacheKey, cacheable, cachedResp := t.BaseRoundTrip(req, false)
 
 	if cacheable && cachedResp != nil {


### PR DESCRIPTION
…by upstream (#177)

* Add default_cache_control for core and traefik

* Move adding default Cache-Control header to bridge.go

* Add to core docs

* Add to traefik plugin docs

* Add for Caddy plugin

* Add to Caddy plugin docs

* Add code and docs for Tyk plugin

* Add Caddy plugin docs to top-level README