### PR TITLE
ci: run tests for pull requests

### DIFF
--- a/.github/workflows/non-regression.yml
+++ b/.github/workflows/non-regression.yml
@@ -2,6 +2,7 @@ name: Build container and validate lint/tests
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/plugins-master.yml
+++ b/.github/workflows/plugins-master.yml
@@ -32,4 +32,4 @@ jobs:
           sudo apt install xcaddy
       -
         name: Build current Souin as caddy module with referenced Souin core version when merge on master
-        run: cd plugins/caddy && xcaddy build --with github.com/darkweak/souin/plugins/caddy@$(git rev-parse --short "$GITHUB_SHA")
+        run: cd plugins/caddy && xcaddy build --with github.com/${{ github.repository }}/plugins/caddy@$(git rev-parse --short "$GITHUB_SHA")

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,6 +1,8 @@
 name: Build and validate Souin as plugins
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   build-caddy-validator:


### PR DESCRIPTION
This enables lint/e2e tests to run on each push of pull requests. Useful for #177.