### PR TITLE
Fix cache cleaning and add proper cache listing based on regexes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,3 +822,4 @@ Thanks to these users for contributing or helping this project in any way
 * [Choelzl](https://github.com/choelzl)
 * [Menci](https://github.com/menci)
 * [Duy Nguyen](https://github.com/duy-nguyen-devops)
+* [Kiss Karoly](https://github.com/kresike)

--- a/api/souin.go
+++ b/api/souin.go
@@ -70,11 +70,11 @@ func (s *SouinAPI) IsEnabled() bool {
 	return s.enabled
 }
 
-func (s *SouinAPI) ListKeys(search string) []string {
-	var res []string
+func (s *SouinAPI) listKeys(search string) []string {
+	res := []string{}
 	re, err := regexp.Compile(search)
 	if err != nil {
-		return nil
+		return res
 	}
 	for _, key := range s.GetAll() {
 		if re.MatchString(key) {
@@ -101,7 +101,7 @@ func (s *SouinAPI) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			res, _ = json.Marshal(s.surrogateStorage.List())
 		} else if compile {
 			search := regexp.MustCompile(s.GetBasePath()+"/(.+)").FindAllStringSubmatch(r.RequestURI, -1)[0][1]
-			res, _ = json.Marshal(s.ListKeys(search))
+			res, _ = json.Marshal(s.listKeys(search))
 			if res == nil {
 				w.WriteHeader(http.StatusNotFound)
 			}

--- a/api/souin.go
+++ b/api/souin.go
@@ -72,12 +72,11 @@ func (s *SouinAPI) IsEnabled() bool {
 
 func (s *SouinAPI) ListKeys(search string) []string {
 	var res []string
-	keys := s.GetAll()
 	re, err := regexp.Compile(search)
 	if err != nil {
 		return nil
 	}
-	for _, key := range keys {
+	for _, key := range s.GetAll() {
 		if re.MatchString(key) {
 			res = append(res, key)
 		}


### PR DESCRIPTION
If specified only lists or purges cache entries that match the given
regular expression. If not specified, lists all and purges all cache.

If i've read correctly you are currently working on getting surrogate keys working properly.
I don't wish to step on your toes, it just seemed more logical to me to be able to list and purge cache contents selectively this way. If you think it's ok, please merge.