### PR TITLE
Redirect headers breakage

### DIFF
--- a/plugins/caddy/httpcache.go
+++ b/plugins/caddy/httpcache.go
@@ -127,10 +127,8 @@ func (s *SouinCaddyPlugin) ServeHTTP(rw http.ResponseWriter, r *http.Request, ne
 			return e
 		}
 
+		customWriter.Response.Header = customWriter.Rw.Header().Clone()
 		combo.req.Response = customWriter.Response
-		if combo.req.Response.Header == nil {
-			combo.req.Response.Header = customWriter.Rw.Header()
-		}
 
 		if combo.req.Response, e = s.Retriever.GetTransport().(*rfc.VaryTransport).UpdateCacheEventually(combo.req); e != nil {
 			return e

--- a/plugins/caddy/httpcache.go
+++ b/plugins/caddy/httpcache.go
@@ -128,6 +128,10 @@ func (s *SouinCaddyPlugin) ServeHTTP(rw http.ResponseWriter, r *http.Request, ne
 		}
 
 		combo.req.Response = customWriter.Response
+		if combo.req.Response.Header == nil {
+			combo.req.Response.Header = customWriter.Rw.Header()
+		}
+
 		if combo.req.Response, e = s.Retriever.GetTransport().(*rfc.VaryTransport).UpdateCacheEventually(combo.req); e != nil {
 			return e
 		}


### PR DESCRIPTION
In case of responses that have no body, headers are incorrectly received from caddy after the first round trip. This can cause some responses to be incorrectly cached.

This little fix copies the missing headers in the proper place.