### PR TITLE
feat(core): Configurable timeout on backend and cache access

### DIFF
--- a/api/souin.go
+++ b/api/souin.go
@@ -103,7 +103,7 @@ func (s *SouinAPI) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		} else if compile {
 			search := regexp.MustCompile(s.GetBasePath()+"/(.+)").FindAllStringSubmatch(r.RequestURI, -1)[0][1]
 			res, _ = json.Marshal(s.listKeys(search))
-			if res == nil {
+			if len(res) == 2 {
 				w.WriteHeader(http.StatusNotFound)
 			}
 		} else {

--- a/api/souin_test.go
+++ b/api/souin_test.go
@@ -1,9 +1,17 @@
 package api
 
 import (
-	"github.com/darkweak/souin/cache/surrogate"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/darkweak/souin/cache/surrogate"
+	surrogate_providers "github.com/darkweak/souin/cache/surrogate/providers"
+	"github.com/darkweak/souin/configurationtypes"
 
 	"github.com/darkweak/souin/api/auth"
 	"github.com/darkweak/souin/cache/providers"
@@ -14,6 +22,9 @@ import (
 
 func mockSouinAPI() *SouinAPI {
 	config := tests.MockConfiguration(tests.BaseConfiguration)
+	config.DefaultCache.CDN = configurationtypes.CDN{
+		Dynamic: true,
+	}
 	prs := providers.InitializeProvider(config)
 	security := auth.InitializeSecurity(config)
 	return &SouinAPI{
@@ -88,4 +99,155 @@ func TestSouinAPI_IsEnabled(t *testing.T) {
 	if !souinMock.IsEnabled() {
 		errors.GenerateError(t, "Souin API should be enabled")
 	}
+}
+
+func TestSouinAPI_listKeys(t *testing.T) {
+	souinMock := mockSouinAPI()
+	souinMock.provider.Set("FIRST_KEY", []byte("Something"), configurationtypes.URL{}, time.Second)
+	souinMock.provider.Set("SECOND_KEY", []byte("Something"), configurationtypes.URL{}, time.Second)
+	souinMock.provider.Set("NOT_MATCH", []byte("Something"), configurationtypes.URL{}, time.Second)
+	souinMock.provider.Set("NOT_MATCH_KEY_SUFFIX", []byte("Something"), configurationtypes.URL{}, time.Second)
+
+	if len(souinMock.listKeys("(error")) != 0 {
+		t.Error("An invalid regexp must return an empty list.")
+	}
+
+	keys := souinMock.listKeys(".+_KEY$")
+
+	if len(keys) != 4 {
+		t.Error("listKeys must return 4 items.")
+	}
+	if keys[0] != "FIRST_KEY" {
+		t.Error("The first key must be equal to FIRST_KEY.")
+	}
+	if keys[1] != "SECOND_KEY" {
+		t.Error("The second key must be equal to SECOND_KEY.")
+	}
+	if keys[2] != "STALE_FIRST_KEY" {
+		t.Error("The third key must be equal to STALE_FIRST_KEY.")
+	}
+	if keys[3] != "STALE_SECOND_KEY" {
+		t.Error("The fourth key must be equal to STALE_SECOND_KEY.")
+	}
+}
+
+type mockSurrogateStorageError struct {
+	*surrogate_providers.SouinSurrogateStorage
+}
+
+func (*mockSurrogateStorageError) Destruct() error {
+	return fmt.Errorf("errored")
+}
+
+func TestSouinAPI_HandleRequest(t *testing.T) {
+	souinMock := mockSouinAPI()
+	souinMock.surrogateStorage.Destruct()
+	souinMock.provider.DeleteMany(".+")
+	souinMock.security = &auth.SecurityAPI{}
+
+	req := httptest.NewRequest(http.MethodGet, "/souin-api/souinbasepath", nil)
+	res := httptest.NewRecorder()
+
+	souinMock.HandleRequest(res, req)
+	b, _ := ioutil.ReadAll(res.Result().Body)
+	if string(b) != "" {
+		t.Error("The response body must be empty due to invalid token.")
+	}
+	if res.Result().StatusCode != http.StatusUnauthorized {
+		t.Error("The response status code must be unauthorized.")
+	}
+
+	sr := res.Result()
+	sr.Header.Set("Surrogate-Key", "THE_KEY")
+	souinMock.provider.Set("first/key/stored", []byte("value"), configurationtypes.URL{}, time.Second)
+	souinMock.surrogateStorage.Store(sr, "first/key/stored")
+	souinMock.security = nil
+	req = httptest.NewRequest(http.MethodGet, "/souin-api/souinbasepath/surrogate_keys", nil)
+	res = httptest.NewRecorder()
+	souinMock.HandleRequest(res, req)
+
+	b, _ = ioutil.ReadAll(res.Result().Body)
+	var surrogates map[string]string
+	_ = json.Unmarshal(b, &surrogates)
+
+	if len(surrogates) != 2 {
+		t.Error("The surrogate storage must have 2 keys.")
+	}
+	if _, ok := surrogates["THE_KEY"]; !ok {
+		t.Error("The key THE_KEY must exist in the surrogate storage.")
+	}
+	if _, ok := surrogates["STALE_THE_KEY"]; !ok {
+		t.Error("The key STALE_THE_KEY must exist in the surrogate storage.")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/souin-api/souinbasepath/inexistent_key", nil)
+	res = httptest.NewRecorder()
+	souinMock.HandleRequest(res, req)
+
+	if res.Result().StatusCode != http.StatusNotFound {
+		t.Error("The endpoint must return an HTTP not found response if the key doesn't exist.")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/souin-api/souinbasepath", nil)
+	res = httptest.NewRecorder()
+	souinMock.HandleRequest(res, req)
+	b, _ = ioutil.ReadAll(res.Result().Body)
+	var values []string
+	_ = json.Unmarshal(b, &values)
+
+	if len(values) != 2 {
+		t.Error("The keys first/key/stored and STALE_first/key/stored must exist in the storage provider.")
+	}
+
+	req = httptest.NewRequest("PURGE", "/souin-api/souinbasepath", nil)
+	req.Header.Set("Surrogate-key", "THE_KEY")
+	res = httptest.NewRecorder()
+	souinMock.HandleRequest(res, req)
+
+	if res.Result().StatusCode != http.StatusNoContent {
+		t.Error("The endpoint must return a no content HTTP response.")
+	}
+
+	req = httptest.NewRequest("PURGE", "/souin-api/souinbasepath/flush", nil)
+	res = httptest.NewRecorder()
+	souinMock.surrogateStorage = &mockSurrogateStorageError{SouinSurrogateStorage: souinMock.surrogateStorage.(*surrogate_providers.SouinSurrogateStorage)}
+	souinMock.HandleRequest(res, req)
+
+	if res.Result().StatusCode != http.StatusNoContent {
+		t.Error("The flush must return a no content HTTP response.")
+	}
+
+	if len(souinMock.provider.ListKeys()) != 0 {
+		t.Error("The provider must not contains keys anymore after a full flush.")
+	}
+	if len(souinMock.surrogateStorage.List()) == 0 {
+		t.Error("The surrogate storage must not contains keys anymore after a full flush error.")
+	}
+
+	res = httptest.NewRecorder()
+	souinMock.surrogateStorage = souinMock.surrogateStorage.(*mockSurrogateStorageError).SouinSurrogateStorage
+	souinMock.HandleRequest(res, req)
+
+	if res.Result().StatusCode != http.StatusNoContent {
+		t.Error("The flush must return a no content HTTP response.")
+	}
+
+	if len(souinMock.provider.ListKeys()) != 0 {
+		t.Error("The provider must not contains keys anymore after a full flush.")
+	}
+	if len(souinMock.surrogateStorage.List()) != 0 {
+		t.Error("The surrogate storage must not contains keys anymore after a full flush.")
+	}
+
+	req = httptest.NewRequest("PURGE", "/souin-api/souinbasepath/one_key", nil)
+	res = httptest.NewRecorder()
+	souinMock.HandleRequest(res, req)
+
+	if res.Result().StatusCode != http.StatusNoContent {
+		t.Error("The endpoint must return a no content HTTP response.")
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/souin-api/souinbasepath", nil)
+	res = httptest.NewRecorder()
+	souinMock.HandleRequest(res, req)
 }

--- a/api/souin_test.go
+++ b/api/souin_test.go
@@ -141,7 +141,7 @@ func (*mockSurrogateStorageError) Destruct() error {
 
 func TestSouinAPI_HandleRequest(t *testing.T) {
 	souinMock := mockSouinAPI()
-	souinMock.surrogateStorage.Destruct()
+	_ = souinMock.surrogateStorage.Destruct()
 	souinMock.provider.DeleteMany(".+")
 	souinMock.security = &auth.SecurityAPI{}
 
@@ -160,7 +160,7 @@ func TestSouinAPI_HandleRequest(t *testing.T) {
 	sr := res.Result()
 	sr.Header.Set("Surrogate-Key", "THE_KEY")
 	souinMock.provider.Set("first/key/stored", []byte("value"), configurationtypes.URL{}, time.Second)
-	souinMock.surrogateStorage.Store(sr, "first/key/stored")
+	_ = souinMock.surrogateStorage.Store(sr, "first/key/stored")
 	souinMock.security = nil
 	req = httptest.NewRequest(http.MethodGet, "/souin-api/souinbasepath/surrogate_keys", nil)
 	res = httptest.NewRecorder()

--- a/cache/surrogate/providers/types.go
+++ b/cache/surrogate/providers/types.go
@@ -19,4 +19,5 @@ type SurrogateInterface interface {
 	ParseHeaders(string) []string
 	List() map[string]string
 	candidateStore(string) bool
+	Destruct() error
 }

--- a/configuration/configuration.sample.yml
+++ b/configuration/configuration.sample.yml
@@ -18,6 +18,7 @@ default_cache: # Required part
     - GET
     - POST
     - HEAD
+  cache_name: Souin # Override the Cache-Status name
   distributed: true # Use Olric distributed storage
   headers: # Default headers concatenated in stored keys
     - Authorization
@@ -31,6 +32,9 @@ default_cache: # Required part
   ttl: 10s # Default TTL
   stale: 10s # Stale duration
   default_cache_control: no-store # Set default value for Cache-Control response header if not set by upstream
+  timeout: # Timeout configuration
+    backend: 10s # Backend timeout before returning an HTTP unavailable response
+    cache: 20ms # Cache provider (badger, etcd, nutsdb, olric, depending the configuration you set) timeout before returning a miss
 log_level: INFO # Logs verbosity [ DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, debug, info, warn, error, dpanic, panic, fatal ]
 reverse_proxy_url: 'http://traefik' # If it's in the same network you can use http://your-service. Then just use https://yourdomain.com
 ssl_providers: # The {providers}.json to usee

--- a/configurationtypes/types.go
+++ b/configurationtypes/types.go
@@ -90,6 +90,13 @@ type CacheProvider struct {
 	Configuration interface{} `json:"configuration" yaml:"configuration"`
 }
 
+// Timeout configuration to handle the cache provider and the
+// reverse-proxy timeout.
+type Timeout struct {
+	Backend Duration `json:"backend" yaml:"backend"`
+	Cache   Duration `json:"cache" yaml:"cache"`
+}
+
 // CDN config
 type CDN struct {
 	APIKey    string `json:"api_key,omitempty" yaml:"api_key,omitempty"`
@@ -123,8 +130,9 @@ type DefaultCache struct {
 	Olric               CacheProvider `json:"olric" yaml:"olric"`
 	Port                Port          `json:"port" yaml:"port"`
 	Regex               Regex         `json:"regex" yaml:"regex"`
-	TTL                 Duration      `json:"ttl" yaml:"ttl"`
 	Stale               Duration      `json:"stale" yaml:"stale"`
+	Timeout             Timeout       `json:"timeout" yaml:"timeout"`
+	TTL                 Duration      `json:"ttl" yaml:"ttl"`
 	DefaultCacheControl string        `json:"default_cache_control" yaml:"default_cache_control"`
 }
 
@@ -183,6 +191,11 @@ func (d *DefaultCache) GetRegex() Regex {
 	return d.Regex
 }
 
+// GetTimeout returns the backend and cache timeouts
+func (d *DefaultCache) GetTimeout() Timeout {
+	return d.Timeout
+}
+
 // GetTTL returns the default TTL
 func (d *DefaultCache) GetTTL() time.Duration {
 	return d.TTL.Duration
@@ -211,8 +224,9 @@ type DefaultCacheInterface interface {
 	GetHeaders() []string
 	GetKey() Key
 	GetRegex() Regex
-	GetTTL() time.Duration
 	GetStale() time.Duration
+	GetTimeout() Timeout
+	GetTTL() time.Duration
 	GetDefaultCacheControl() string
 }
 

--- a/context/timeout.go
+++ b/context/timeout.go
@@ -1,0 +1,43 @@
+package context
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/darkweak/souin/configurationtypes"
+)
+
+const (
+	TimeoutCache  ctxKey = "TIMEOUT_CACHE"
+	TimeoutCancel ctxKey = "TIMEOUT_CANCEL"
+)
+
+const (
+	defaultTimeoutBackend = 10 * time.Second
+	defaultTimeoutCache   = 10 * time.Millisecond
+)
+
+type timeoutContext struct {
+	timeoutCache, timeoutBackend time.Duration
+}
+
+func (t *timeoutContext) SetupContext(c configurationtypes.AbstractConfigurationInterface) {
+	t.timeoutBackend = defaultTimeoutBackend
+	t.timeoutCache = defaultTimeoutCache
+	if c.GetDefaultCache().GetTimeout().Cache.Duration != 0 {
+		t.timeoutCache = c.GetDefaultCache().GetTimeout().Cache.Duration
+	}
+	if c.GetDefaultCache().GetTimeout().Backend.Duration != 0 {
+		t.timeoutBackend = c.GetDefaultCache().GetTimeout().Backend.Duration
+	}
+	c.GetLogger().Sugar().Infof("Set backend timeout to %v", t.timeoutBackend)
+	c.GetLogger().Sugar().Infof("Set cache timeout to %v", t.timeoutBackend)
+}
+
+func (t *timeoutContext) SetContext(req *http.Request) *http.Request {
+	ctx, cancel := context.WithTimeout(req.Context(), t.timeoutBackend)
+	return req.WithContext(context.WithValue(context.WithValue(ctx, TimeoutCancel, cancel), TimeoutCache, t.timeoutCache))
+}
+
+var _ ctx = (*cacheContext)(nil)

--- a/context/timeout_test.go
+++ b/context/timeout_test.go
@@ -1,0 +1,77 @@
+package context
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/darkweak/souin/configurationtypes"
+	"github.com/darkweak/souin/plugins/souin/configuration"
+	"go.uber.org/zap"
+)
+
+func Test_TimeoutContext_SetupContext(t *testing.T) {
+	dc := configurationtypes.DefaultCache{}
+	c := configuration.Configuration{
+		DefaultCache: &dc,
+	}
+	c.SetLogger(zap.NewNop())
+	ctx := timeoutContext{}
+
+	ctx.SetupContext(&c)
+	if ctx.timeoutBackend != defaultTimeoutBackend {
+		t.Error("The timeout backend must be equal to the default timeout backend when no directives are given.")
+	}
+	if ctx.timeoutCache != defaultTimeoutCache {
+		t.Error("The timeout cache must be equal to the default timeout cache when no directives are given.")
+	}
+
+	c.DefaultCache.Timeout.Backend = configurationtypes.Duration{Duration: time.Second}
+	ctx.SetupContext(&c)
+	if ctx.timeoutBackend != time.Second {
+		t.Error("The timeout backend must be equal to one second when a directive is given.")
+	}
+	if ctx.timeoutCache != defaultTimeoutCache {
+		t.Error("The timeout cache must be equal to the default timeout cache when no directives are given.")
+	}
+
+	c.DefaultCache.Timeout = configurationtypes.Timeout{}
+	c.DefaultCache.Timeout.Cache = configurationtypes.Duration{Duration: time.Second}
+	ctx.SetupContext(&c)
+	if ctx.timeoutBackend != defaultTimeoutBackend {
+		t.Error("The timeout backend must be equal to 10 seconds when no directives are given.")
+	}
+	if ctx.timeoutCache != time.Second {
+		t.Error("The timeout cache must be equal to one second when a directive is given.")
+	}
+}
+
+func Test_TimeoutContext_SetContext(t *testing.T) {
+	dc := configurationtypes.DefaultCache{
+		Timeout: configurationtypes.Timeout{
+			Backend: configurationtypes.Duration{
+				Duration: time.Second,
+			},
+			Cache: configurationtypes.Duration{
+				Duration: time.Millisecond,
+			},
+		},
+	}
+	c := configuration.Configuration{
+		DefaultCache: &dc,
+	}
+	c.SetLogger(zap.NewNop())
+	ctx := timeoutContext{}
+	ctx.SetupContext(&c)
+
+	req := httptest.NewRequest(http.MethodGet, "http://domain.com", nil)
+	req = ctx.SetContext(req)
+	if req.Context().Value(TimeoutCache).(time.Duration) != time.Millisecond {
+		t.Error("The TimeoutCache context must be set in the request.")
+	}
+	if req.Context().Value(TimeoutCancel).(context.CancelFunc) == nil {
+		t.Error("The TimeoutCancel context must be set and be a CancelFunc.")
+	}
+}

--- a/context/types.go
+++ b/context/types.go
@@ -19,6 +19,7 @@ type (
 		GraphQL   ctx
 		Key       ctx
 		Method    ctx
+		Timeout   ctx
 	}
 )
 
@@ -28,6 +29,7 @@ func GetContext() *Context {
 		GraphQL:   &graphQLContext{},
 		Key:       &keyContext{},
 		Method:    &methodContext{},
+		Timeout:   &timeoutContext{},
 	}
 }
 
@@ -36,10 +38,11 @@ func (c *Context) Init(co configurationtypes.AbstractConfigurationInterface) {
 	c.GraphQL.SetupContext(co)
 	c.Key.SetupContext(co)
 	c.Method.SetupContext(co)
+	c.Timeout.SetupContext(co)
 }
 
 func (c *Context) SetBaseContext(req *http.Request) *http.Request {
-	return c.Method.SetContext(c.CacheName.SetContext(req))
+	return c.Timeout.SetContext(c.Method.SetContext(c.CacheName.SetContext(req)))
 }
 
 func (c *Context) SetContext(req *http.Request) *http.Request {

--- a/plugins/base.go
+++ b/plugins/base.go
@@ -109,6 +109,7 @@ func DefaultSouinPluginCallback(
 	rc coalescing.RequestCoalescingInterface,
 	nextMiddleware func(w http.ResponseWriter, r *http.Request) error,
 ) (e error) {
+	retriever.GetConfiguration().GetLogger().Sugar().Debugf("Incoming request: %+v", req)
 	prometheus.Increment(prometheus.RequestCounter)
 	start := time.Now()
 	cacheCandidate := !strings.Contains(req.Header.Get("Cache-Control"), "no-cache")
@@ -160,6 +161,7 @@ func DefaultSouinPluginCallback(
 			return e
 		}
 		if entry != nil {
+			retriever.GetConfiguration().GetLogger().Sugar().Debugf("Serve response from the cache: %+v", entry)
 			sendAnyCachedResponse(entry.Header, entry, res)
 
 			return

--- a/plugins/base.go
+++ b/plugins/base.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"bytes"
+	ctx "context"
 	"io/ioutil"
 	"net/http"
 	"regexp"
@@ -23,6 +24,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+var serverTimeoutMessage = []byte("Internal server error")
 
 // CustomWriter handles the response and provide the way to cache the value
 type CustomWriter struct {
@@ -111,33 +114,61 @@ func DefaultSouinPluginCallback(
 	cacheCandidate := !strings.Contains(req.Header.Get("Cache-Control"), "no-cache")
 	cacheKey := req.Context().Value(context.Key).(string)
 	retriever.SetMatchedURLFromRequest(req)
+	timeoutCache := req.Context().Value(context.TimeoutCache).(time.Duration)
+	cancel := req.Context().Value(context.TimeoutCancel).(ctx.CancelFunc)
+	defer cancel()
+	foundEntry := make(chan *http.Response)
+	errorCacheCh := make(chan error)
 
-	if cacheCandidate {
-		r, stale, err := rfc.CachedResponse(
-			retriever.GetProvider(),
-			req,
-			cacheKey,
-			retriever.GetTransport(),
-		)
-		if err != nil {
-			retriever.GetConfiguration().GetLogger().Sugar().Debugf("An error ocurred while retrieving the (stale)? key %s: %v", cacheKey, err)
-			return err
-		}
+	go func() {
+		if cacheCandidate {
+			r, stale, err := rfc.CachedResponse(
+				retriever.GetProvider(),
+				req,
+				cacheKey,
+				retriever.GetTransport(),
+			)
+			if err != nil {
+				retriever.GetConfiguration().GetLogger().Sugar().Debugf("An error ocurred while retrieving the (stale)? key %s: %v", cacheKey, err)
+				foundEntry <- nil
+				errorCacheCh <- err
 
-		if r != nil {
-			rh := r.Header
-			if stale {
-				rfc.HitStaleCache(&rh, retriever.GetMatchedURL().TTL.Duration)
-			} else {
-				prometheus.Increment(prometheus.CachedResponseCounter)
+				return
 			}
-			sendAnyCachedResponse(rh, r, res)
+
+			if r != nil {
+				rh := r.Header
+				if stale {
+					rfc.HitStaleCache(&rh, retriever.GetMatchedURL().TTL.Duration)
+					r.Header = rh
+				} else {
+					prometheus.Increment(prometheus.CachedResponseCounter)
+				}
+				foundEntry <- r
+				errorCacheCh <- nil
+
+				return
+			}
+		}
+		foundEntry <- nil
+		errorCacheCh <- nil
+	}()
+
+	select {
+	case entry := <-foundEntry:
+		if e = <-errorCacheCh; e != nil {
+			return e
+		}
+		if entry != nil {
+			sendAnyCachedResponse(entry.Header, entry, res)
 
 			return
 		}
+	case <-time.After(timeoutCache):
 	}
 
 	coalesceable := make(chan bool)
+	errorBackendCh := make(chan error)
 	defer close(coalesceable)
 	go func() {
 		defer func() {
@@ -146,14 +177,34 @@ func DefaultSouinPluginCallback(
 		coalesceable <- retriever.GetTransport().GetCoalescingLayerStorage().Exists(cacheKey)
 	}()
 	prometheus.Increment(prometheus.NoCachedResponseCounter)
-	if <-coalesceable && rc != nil {
-		rc.Temporize(req, res, nextMiddleware)
-	} else {
-		e = nextMiddleware(res, req)
-	}
+
+	go func() {
+		if rc != nil && <-coalesceable {
+			rc.Temporize(req, res, nextMiddleware)
+		} else {
+			errorBackendCh <- nextMiddleware(res, req)
+			return
+		}
+		errorBackendCh <- nil
+	}()
+
 	prometheus.Add(prometheus.AvgResponseTime, float64(time.Since(start).Milliseconds()))
 
-	return e
+	select {
+	case <-req.Context().Done():
+		switch req.Context().Err() {
+		case ctx.DeadlineExceeded:
+			cw := res.(*CustomWriter)
+			rfc.MissCache(cw.Header().Set, req)
+			cw.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = cw.Rw.Write(serverTimeoutMessage)
+			return ctx.DeadlineExceeded
+		}
+	case v := <-errorBackendCh:
+		return v
+	}
+
+	return nil
 }
 
 // DefaultSouinPluginInitializerFromConfiguration is the default initialization for plugins

--- a/plugins/beego/souin.go
+++ b/plugins/beego/souin.go
@@ -168,6 +168,27 @@ func configurationPropertyMapper(c map[string]interface{}) plugins.BaseConfigura
 					if exclude != "" {
 						dc.Regex = configurationtypes.Regex{Exclude: exclude}
 					}
+				case "timeout":
+					timeout := configurationtypes.Timeout{}
+					for timeoutK, timeoutV := range defaultCacheV.(map[string]interface{}) {
+						switch timeoutK {
+						case "backend":
+							d := configurationtypes.Duration{}
+							ttl, err := time.ParseDuration(timeoutV.(string))
+							if err == nil {
+								d.Duration = ttl
+							}
+							timeout.Backend = d
+						case "cache":
+							d := configurationtypes.Duration{}
+							ttl, err := time.ParseDuration(timeoutV.(string))
+							if err == nil {
+								d.Duration = ttl
+							}
+							timeout.Cache = d
+						}
+					}
+					dc.Timeout = timeout
 				case "ttl":
 					ttl, err := time.ParseDuration(defaultCacheV.(string))
 					if err == nil {

--- a/plugins/caddy/Caddyfile
+++ b/plugins/caddy/Caddyfile
@@ -20,6 +20,10 @@
         headers Content-Type Authorization
         log_level debug
         ttl 1000s
+        timeout {
+            backend 10s
+            cache 100ns
+        }
         default_cache_control public
     }
 }
@@ -43,6 +47,62 @@ cache @match2 {
 
 cache @matchdefault {
     ttl 5s
+}
+
+route /badger-configuration {
+    cache {
+        ttl 15s
+        badger {
+            configuration {
+                Dir /tmp/badger-configuration
+                ValueDir match2
+                ValueLogFileSize 16777216
+                MemTableSize 4194304
+                ValueThreshold 524288
+            }
+        }
+    }
+    respond "Hello badger"
+}
+
+route /etcd-configuration {
+    cache {
+        ttl 15s
+        etcd {
+            configuration {
+                Endpoints etcd1:2379 etcd2:2379 etcd3:2379
+                AutoSyncInterval 1s
+                DialTimeout 1s
+                DialKeepAliveTime 1s
+                DialKeepAliveTimeout 1s
+                MaxCallSendMsgSize 10000000
+                MaxCallRecvMsgSize 10000000
+                Username john
+                Password doe
+                RejectOldCluster false
+                PermitWithoutStream false
+            }
+        }
+    }
+    respond "Hello etcd"
+}
+
+route /nuts-configuration {
+    cache {
+        ttl 15s
+        nuts {
+            configuration {
+                Dir /tmp/nuts-configuration
+                EntryIdxMode 1
+                RWMode 0
+                SegmentSize 1024
+                NodeNum 42
+                SyncEnable true
+                StartFileLoadingMode 1
+            }
+        }
+    }
+    respond "Hello nuts"
 }
 
 route /vary {
@@ -97,6 +157,17 @@ route /another-cache-status-name {
     cache {
         cache_name Another
     }
+}
+
+route /backend-timeout {
+    cache {
+        log_level debug
+        timeout {
+            backend 1s
+            cache 1ms
+        }
+    }
+    reverse_proxy 127.0.0.1:8081
 }
 
 cache @souin-api {

--- a/plugins/caddy/Caddyfile
+++ b/plugins/caddy/Caddyfile
@@ -22,7 +22,7 @@
         ttl 1000s
         timeout {
             backend 10s
-            cache 100ns
+            cache 10ms
         }
         default_cache_control public
     }

--- a/plugins/caddy/README.md
+++ b/plugins/caddy/README.md
@@ -174,6 +174,62 @@ cache @matchdefault {
     }
 }
 
+route /badger-configuration {
+    cache {
+        ttl 15s
+        badger {
+            configuration {
+                Dir /tmp/badger-configuration
+                ValueDir match2
+                ValueLogFileSize 16777216
+                MemTableSize 4194304
+                ValueThreshold 524288
+            }
+        }
+    }
+    respond "Hello badger"
+}
+
+route /etcd-configuration {
+    cache {
+        ttl 15s
+        etcd {
+            configuration {
+                Endpoints etcd1:2379 etcd2:2379 etcd3:2379
+                AutoSyncInterval 1s
+                DialTimeout 1s
+                DialKeepAliveTime 1s
+                DialKeepAliveTimeout 1s
+                MaxCallSendMsgSize 10000000
+                MaxCallRecvMsgSize 10000000
+                Username john
+                Password doe
+                RejectOldCluster false
+                PermitWithoutStream false
+            }
+        }
+    }
+    respond "Hello etcd"
+}
+
+route /nuts-configuration {
+    cache {
+        ttl 15s
+        nuts {
+            configuration {
+                Dir /tmp/nuts-configuration
+                EntryIdxMode 1
+                RWMode 0
+                SegmentSize 1024
+                NodeNum 42
+                SyncEnable true
+                StartFileLoadingMode 1
+            }
+        }
+    }
+    respond "Hello nuts"
+}
+
 cache @souin-api {}
 ```
 What does these directives mean?  
@@ -219,6 +275,9 @@ What does these directives mean?
 | `olric.configuration`              | Configure Olric directly in the Caddyfile or your JSON caddy configuration                                                                   | [See the Olric configuration for the options](https://github.com/buraksezer/olric/blob/master/cmd/olricd/olricd.yaml/)  |
 | `regex.exclude`                    | The regex used to prevent paths being cached                                                                                                 | `^[A-z]+.*$`                                                                                                            |
 | `stale`                            | The stale duration                                                                                                                           | `25m`                                                                                                                   |
+| `timeout`                          | The timeout configuration                                                                                                                    |                                                                                                                           |
+| `timeout.backend`                  | The timeout duration to consider the backend as unreachable                                                                                  | `10s`                                                                                                                     |
+| `timeout.cache`                    | The timeout duration to consider the cache provider as unreachable                                                                           | `10ms`                                                                                                                    |
 | `ttl`                              | The TTL duration                                                                                                                             | `120s`                                                                                                                  |
 | `log_level`                        | The log level                                                                                                                                | `One of DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL it's case insensitive`                                           |
 

--- a/plugins/caddy/configuration.go
+++ b/plugins/caddy/configuration.go
@@ -21,6 +21,7 @@ type DefaultCache struct {
 	Etcd                configurationtypes.CacheProvider `json:"etcd"`
 	Nuts                configurationtypes.CacheProvider `json:"nuts"`
 	Regex               configurationtypes.Regex         `json:"regex"`
+	Timeout             configurationtypes.Timeout       `json:"timeout"`
 	TTL                 configurationtypes.Duration      `json:"ttl"`
 	Stale               configurationtypes.Duration      `json:"stale"`
 }
@@ -78,6 +79,11 @@ func (d *DefaultCache) GetOlric() configurationtypes.CacheProvider {
 // GetRegex returns the regex that shouldn't be cached
 func (d *DefaultCache) GetRegex() configurationtypes.Regex {
 	return d.Regex
+}
+
+// GetTimeout returns the backend and cache timeouts
+func (d *DefaultCache) GetTimeout() configurationtypes.Timeout {
+	return d.Timeout
 }
 
 // GetTTL returns the default TTL

--- a/plugins/caddy/httpcache.go
+++ b/plugins/caddy/httpcache.go
@@ -215,6 +215,10 @@ func (s *SouinCaddyPlugin) FromApp(app *SouinApp) error {
 	if dc.Headers == nil {
 		s.Configuration.DefaultCache.Headers = appDc.Headers
 	}
+
+	if s.Configuration.LogLevel == "" {
+		s.Configuration.LogLevel = app.LogLevel
+	}
 	if dc.TTL.Duration == 0 {
 		s.Configuration.DefaultCache.TTL = appDc.TTL
 	}
@@ -611,6 +615,7 @@ func parseCaddyfileGlobalOption(h *caddyfile.Dispenser, _ interface{}) (interfac
 	souinApp.DefaultCache = cfg.DefaultCache
 	souinApp.API = cfg.API
 	souinApp.CacheKeys = cfg.CfgCacheKeys
+	souinApp.LogLevel = cfg.LogLevel
 
 	return httpcaddyfile.App{
 		Name:  moduleName,

--- a/plugins/caddy/httpcache.go
+++ b/plugins/caddy/httpcache.go
@@ -70,6 +70,8 @@ type SouinCaddyPlugin struct {
 	// Enable the Olric distributed cache storage.
 	Olric configurationtypes.CacheProvider `json:"olric,omitempty"`
 	// Time to live for a key, using time.duration.
+	Timeout configurationtypes.Timeout `json:"timeout,omitempty"`
+	// Time to live for a key, using time.duration.
 	TTL configurationtypes.Duration `json:"ttl,omitempty"`
 	// Time to live for a stale key, using time.duration.
 	Stale configurationtypes.Duration `json:"stale,omitempty"`
@@ -154,6 +156,7 @@ func (s *SouinCaddyPlugin) configurationPropertyMapper() error {
 		Headers:             s.Headers,
 		Olric:               s.Olric,
 		Etcd:                s.Etcd,
+		Timeout:             s.Timeout,
 		TTL:                 s.TTL,
 		Stale:               s.Stale,
 	}
@@ -191,6 +194,7 @@ func (s *SouinCaddyPlugin) FromApp(app *SouinApp) error {
 			Stale:               app.Stale,
 			DefaultCacheControl: app.DefaultCacheControl,
 			CacheName:           app.CacheName,
+			Timeout:             app.Timeout,
 		}
 		return nil
 	}
@@ -217,6 +221,12 @@ func (s *SouinCaddyPlugin) FromApp(app *SouinApp) error {
 	if dc.Stale.Duration == 0 {
 		s.Configuration.DefaultCache.Stale = appDc.Stale
 	}
+	if dc.Timeout.Backend.Duration == 0 {
+		s.Configuration.DefaultCache.Timeout.Backend = appDc.Timeout.Backend
+	}
+	if dc.Timeout.Cache.Duration == 0 {
+		s.Configuration.DefaultCache.Timeout.Cache = appDc.Timeout.Cache
+	}
 	if !dc.Key.DisableBody && !dc.Key.DisableHost && !dc.Key.DisableMethod {
 		s.Configuration.DefaultCache.Key = appDc.Key
 	}
@@ -226,18 +236,16 @@ func (s *SouinCaddyPlugin) FromApp(app *SouinApp) error {
 	if dc.CacheName == "" {
 		s.Configuration.DefaultCache.CacheName = appDc.CacheName
 	}
-	if dc.Olric.URL == "" || dc.Olric.Path == "" || dc.Olric.Configuration == nil {
-		s.Configuration.DefaultCache.Distributed = appDc.Distributed
+	if dc.Olric.URL == "" && dc.Olric.Path == "" && dc.Olric.Configuration == nil {
 		s.Configuration.DefaultCache.Olric = appDc.Olric
 	}
 	if dc.Etcd.Configuration == nil {
-		s.Configuration.DefaultCache.Distributed = appDc.Distributed
 		s.Configuration.DefaultCache.Etcd = appDc.Etcd
 	}
 	if dc.Badger.Path == "" || dc.Badger.Configuration == nil {
 		s.Configuration.DefaultCache.Badger = appDc.Badger
 	}
-	if dc.Nuts.Path == "" || dc.Nuts.Configuration == nil {
+	if dc.Nuts.Path == "" && dc.Nuts.Configuration == nil {
 		s.Configuration.DefaultCache.Nuts = appDc.Nuts
 	}
 	if dc.Regex.Exclude == "" {
@@ -315,9 +323,6 @@ func (s *SouinCaddyPlugin) Provision(ctx caddy.Context) error {
 
 	if app.Provider == nil {
 		app.Provider = s.Retriever.GetProvider()
-	} else {
-		s.Retriever.(*types.RetrieverResponseProperties).Provider = app.Provider
-		s.Retriever.GetTransport().(*rfc.VaryTransport).Provider = app.Provider
 	}
 
 	if app.SurrogateStorage == nil {
@@ -569,6 +574,28 @@ func parseCaddyfileGlobalOption(h *caddyfile.Dispenser, _ interface{}) (interfac
 				if err == nil {
 					cfg.DefaultCache.Stale.Duration = stale
 				}
+			case "timeout":
+				timeout := configurationtypes.Timeout{}
+				for nesting := h.Nesting(); h.NextBlock(nesting); {
+					directive := h.Val()
+					switch directive {
+					case "backend":
+						d := configurationtypes.Duration{}
+						ttl, err := time.ParseDuration(h.RemainingArgs()[0])
+						if err == nil {
+							d.Duration = ttl
+						}
+						timeout.Backend = d
+					case "cache":
+						d := configurationtypes.Duration{}
+						ttl, err := time.ParseDuration(h.RemainingArgs()[0])
+						if err == nil {
+							d.Duration = ttl
+						}
+						timeout.Cache = d
+					}
+				}
+				cfg.DefaultCache.Timeout = timeout
 			case "ttl":
 				args := h.RemainingArgs()
 				ttl, err := time.ParseDuration(args[0])
@@ -649,6 +676,17 @@ func parseCaddyfileHandlerDirective(h httpcaddyfile.Helper) (caddyhttp.Middlewar
 			sc.DefaultCache.CacheName = args[0]
 		case "default_cache_control":
 			sc.DefaultCache.DefaultCacheControl = strings.Join(h.RemainingArgs(), " ")
+		case "etcd":
+			sc.DefaultCache.Distributed = true
+			provider := configurationtypes.CacheProvider{}
+			for nesting := h.Nesting(); h.NextBlock(nesting); {
+				directive := h.Val()
+				switch directive {
+				case "configuration":
+					provider.Configuration = parseCaddyfileRecursively(h.Dispenser)
+				}
+			}
+			sc.DefaultCache.Etcd = provider
 		case "headers":
 			sc.DefaultCache.Headers = h.RemainingArgs()
 		case "key":
@@ -665,11 +703,66 @@ func parseCaddyfileHandlerDirective(h httpcaddyfile.Helper) (caddyhttp.Middlewar
 				}
 			}
 			sc.DefaultCache.Key = config_key
+		case "olric":
+			sc.DefaultCache.Distributed = true
+			provider := configurationtypes.CacheProvider{}
+			for nesting := h.Nesting(); h.NextBlock(nesting); {
+				directive := h.Val()
+				switch directive {
+				case "url":
+					urlArgs := h.RemainingArgs()
+					provider.URL = urlArgs[0]
+				case "path":
+					urlArgs := h.RemainingArgs()
+					provider.Path = urlArgs[0]
+				case "configuration":
+					provider.Configuration = parseCaddyfileRecursively(h.Dispenser)
+				}
+			}
+			sc.DefaultCache.Olric = provider
+		case "nuts":
+			provider := configurationtypes.CacheProvider{}
+			for nesting := h.Nesting(); h.NextBlock(nesting); {
+				directive := h.Val()
+				switch directive {
+				case "url":
+					urlArgs := h.RemainingArgs()
+					provider.URL = urlArgs[0]
+				case "path":
+					urlArgs := h.RemainingArgs()
+					provider.Path = urlArgs[0]
+				case "configuration":
+					provider.Configuration = parseCaddyfileRecursively(h.Dispenser)
+				}
+			}
+			sc.DefaultCache.Nuts = provider
 		case "stale":
 			stale, err := time.ParseDuration(h.RemainingArgs()[0])
 			if err == nil {
 				sc.DefaultCache.Stale.Duration = stale
 			}
+		case "timeout":
+			timeout := configurationtypes.Timeout{}
+			for nesting := h.Nesting(); h.NextBlock(nesting); {
+				directive := h.Val()
+				switch directive {
+				case "backend":
+					d := configurationtypes.Duration{}
+					ttl, err := time.ParseDuration(h.RemainingArgs()[0])
+					if err == nil {
+						d.Duration = ttl
+					}
+					timeout.Backend = d
+				case "cache":
+					d := configurationtypes.Duration{}
+					ttl, err := time.ParseDuration(h.RemainingArgs()[0])
+					if err == nil {
+						d.Duration = ttl
+					}
+					timeout.Cache = d
+				}
+			}
+			sc.DefaultCache.Timeout = timeout
 		case "ttl":
 			ttl, err := time.ParseDuration(h.RemainingArgs()[0])
 			if err == nil {

--- a/plugins/kratos/configuration.go
+++ b/plugins/kratos/configuration.go
@@ -225,6 +225,30 @@ func parseDefaultCache(dcConfiguration map[string]config.Value) *configurationty
 			if exclude != "" {
 				dc.Regex = configurationtypes.Regex{Exclude: exclude}
 			}
+		case "timeout":
+			timeout := configurationtypes.Timeout{}
+			timeoutConfiguration, _ := defaultCacheV.Map()
+			for timeoutK, timeoutV := range timeoutConfiguration {
+				switch timeoutK {
+				case "backend":
+					d := configurationtypes.Duration{}
+					sttl, err := timeoutV.String()
+					ttl, _ := time.ParseDuration(sttl)
+					if err == nil {
+						d.Duration = ttl
+					}
+					timeout.Backend = d
+				case "cache":
+					d := configurationtypes.Duration{}
+					sttl, err := timeoutV.String()
+					ttl, _ := time.ParseDuration(sttl)
+					if err == nil {
+						d.Duration = ttl
+					}
+					timeout.Cache = d
+				}
+			}
+			dc.Timeout = timeout
 		case "ttl":
 			sttl, err := defaultCacheV.String()
 			ttl, _ := time.ParseDuration(sttl)

--- a/plugins/kratos/configuration.go
+++ b/plugins/kratos/configuration.go
@@ -140,6 +140,8 @@ func parseDefaultCache(dcConfiguration map[string]config.Value) *configurationty
 				}
 			}
 			dc.Badger = provider
+		case "cache_name":
+			dc.CacheName, _ = defaultCacheV.String()
 		case "cdn":
 			cdn := configurationtypes.CDN{}
 			cdnConfiguration, _ := defaultCacheV.Map()

--- a/plugins/roadrunner/README.md
+++ b/plugins/roadrunner/README.md
@@ -61,6 +61,9 @@ http:
         - Authorization
       regex:
         exclude: '/excluded'
+      timeout:
+        backend: 5s
+        cache: 1ms
       ttl: 5s
       stale: 10s
     log_level: debug

--- a/plugins/roadrunner/configuration.go
+++ b/plugins/roadrunner/configuration.go
@@ -175,6 +175,27 @@ func parseDefaultCache(dcConfiguration map[string]interface{}) *configurationtyp
 			if v["exclude"] != "" {
 				dc.Regex = configurationtypes.Regex{Exclude: v["exclude"].(string)}
 			}
+		case "timeout":
+			timeout := configurationtypes.Timeout{}
+			for timeoutK, timeoutV := range defaultCacheV.(map[string]interface{}) {
+				switch timeoutK {
+				case "backend":
+					d := configurationtypes.Duration{}
+					ttl, err := time.ParseDuration(timeoutV.(string))
+					if err == nil {
+						d.Duration = ttl
+					}
+					timeout.Backend = d
+				case "cache":
+					d := configurationtypes.Duration{}
+					ttl, err := time.ParseDuration(timeoutV.(string))
+					if err == nil {
+						d.Duration = ttl
+					}
+					timeout.Cache = d
+				}
+			}
+			dc.Timeout = timeout
 		case "ttl":
 			ttl, err := time.ParseDuration(defaultCacheV.(string))
 			if err == nil {

--- a/plugins/traefik/base.go
+++ b/plugins/traefik/base.go
@@ -174,6 +174,8 @@ func DefaultSouinPluginCallback(
 			_, _ = cw.Rw.Write([]byte("Internal server error"))
 			return
 		}
+	case <-errorBackendCh:
+		return
 	}
 }
 

--- a/plugins/traefik/base.go
+++ b/plugins/traefik/base.go
@@ -2,11 +2,13 @@ package traefik
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/darkweak/souin/api"
 	"github.com/darkweak/souin/cache/coalescing"
@@ -112,27 +114,67 @@ func DefaultSouinPluginCallback(
 ) {
 	cacheKey := req.Context().Value(souin_ctx.Key).(string)
 	retriever.SetMatchedURLFromRequest(req)
+	timeoutCache := req.Context().Value(souin_ctx.TimeoutCache).(time.Duration)
+	cancel := req.Context().Value(souin_ctx.TimeoutCancel).(context.CancelFunc)
+	defer cancel()
+	foundEntry := make(chan *http.Response)
+	errorCacheCh := make(chan error)
 
-	if !strings.Contains(req.Header.Get("Cache-Control"), "no-cache") {
-		r, stale, _ := rfc.CachedResponse(
-			retriever.GetProvider(),
-			req,
-			cacheKey,
-			retriever.GetTransport(),
-		)
+	go func() {
+		if !strings.Contains(req.Header.Get("Cache-Control"), "no-cache") {
+			r, stale, _ := rfc.CachedResponse(
+				retriever.GetProvider(),
+				req,
+				cacheKey,
+				retriever.GetTransport(),
+			)
 
-		if r != nil {
-			rh := r.Header
-			if stale {
-				rfc.HitStaleCache(&rh, retriever.GetMatchedURL().TTL.Duration)
+			if r != nil {
+				rh := r.Header
+				if stale {
+					rfc.HitStaleCache(&rh, retriever.GetMatchedURL().TTL.Duration)
+					r.Header = rh
+				}
+				foundEntry <- r
+				errorCacheCh <- nil
+
+				return
 			}
-			sendAnyCachedResponse(rh, r, res)
+		}
 
+		foundEntry <- nil
+		errorCacheCh <- nil
+	}()
+
+	select {
+	case entry := <-foundEntry:
+		if e := <-errorCacheCh; e != nil {
+			return
+		}
+		if entry != nil {
+			sendAnyCachedResponse(entry.Header, entry, res)
+			return
+		}
+	case <-time.After(timeoutCache):
+	}
+
+	errorBackendCh := make(chan error)
+
+	go func() {
+		errorBackendCh <- nextMiddleware(res, req)
+	}()
+
+	select {
+	case <-req.Context().Done():
+		switch req.Context().Err() {
+		case context.DeadlineExceeded:
+			cw := res.(*CustomWriter)
+			rfc.MissCache(cw.Header().Set, req)
+			cw.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = cw.Rw.Write([]byte("Internal server error"))
 			return
 		}
 	}
-
-	_ = nextMiddleware(res, req)
 }
 
 // DefaultSouinPluginInitializerFromConfiguration is the default initialization for plugins

--- a/plugins/traefik/main.go
+++ b/plugins/traefik/main.go
@@ -118,6 +118,28 @@ func parseConfiguration(c map[string]interface{}) Configuration {
 					if exclude != "" {
 						dc.Regex = configurationtypes.Regex{Exclude: exclude}
 					}
+				case "timeout":
+					timeout := configurationtypes.Timeout{}
+					timeoutConfiguration := defaultCacheV.(map[string]interface{})
+					for timeoutK, timeoutV := range timeoutConfiguration {
+						switch timeoutK {
+						case "backend":
+							d := configurationtypes.Duration{}
+							ttl, err := time.ParseDuration(timeoutV.(string))
+							if err == nil {
+								d.Duration = ttl
+							}
+							timeout.Backend = d
+						case "cache":
+							d := configurationtypes.Duration{}
+							ttl, err := time.ParseDuration(timeoutV.(string))
+							if err == nil {
+								d.Duration = ttl
+							}
+							timeout.Cache = d
+						}
+					}
+					dc.Timeout = timeout
 				case "ttl":
 					ttl, err := time.ParseDuration(defaultCacheV.(string))
 					if err == nil {

--- a/plugins/traefik/override/context/timeout.go
+++ b/plugins/traefik/override/context/timeout.go
@@ -1,0 +1,41 @@
+package context
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/darkweak/souin/configurationtypes"
+)
+
+const (
+	TimeoutCache  ctxKey = "TIMEOUT_CACHE"
+	TimeoutCancel ctxKey = "TIMEOUT_CANCEL"
+)
+
+const (
+	defaultTimeoutBackend = 10 * time.Second
+	defaultTimeoutCache   = 10 * time.Millisecond
+)
+
+type timeoutContext struct {
+	timeoutCache, timeoutBackend time.Duration
+}
+
+func (t *timeoutContext) SetupContext(c configurationtypes.AbstractConfigurationInterface) {
+	t.timeoutBackend = defaultTimeoutBackend
+	t.timeoutCache = defaultTimeoutCache
+	if c.GetDefaultCache().GetTimeout().Cache.Duration != 0 {
+		t.timeoutCache = c.GetDefaultCache().GetTimeout().Cache.Duration
+	}
+	if c.GetDefaultCache().GetTimeout().Backend.Duration != 0 {
+		t.timeoutBackend = c.GetDefaultCache().GetTimeout().Backend.Duration
+	}
+}
+
+func (t *timeoutContext) SetContext(req *http.Request) *http.Request {
+	ctx, cancel := context.WithTimeout(req.Context(), t.timeoutBackend)
+	return req.WithContext(context.WithValue(context.WithValue(ctx, TimeoutCancel, cancel), TimeoutCache, t.timeoutCache))
+}
+
+var _ ctx = (*cacheContext)(nil)

--- a/plugins/traefik/override/context/types.go
+++ b/plugins/traefik/override/context/types.go
@@ -19,6 +19,7 @@ type (
 		GraphQL   ctx
 		Key       ctx
 		Method    ctx
+		Timeout   ctx
 	}
 )
 
@@ -28,6 +29,7 @@ func GetContext() *Context {
 		GraphQL:   &graphQLContext{},
 		Key:       &keyContext{},
 		Method:    &methodContext{},
+		Timeout:   &timeoutContext{},
 	}
 }
 
@@ -36,10 +38,11 @@ func (c *Context) Init(co configurationtypes.AbstractConfigurationInterface) {
 	c.GraphQL.SetupContext(co)
 	c.Key.SetupContext(co)
 	c.Method.SetupContext(co)
+	c.Timeout.SetupContext(co)
 }
 
 func (c *Context) SetBaseContext(req *http.Request) *http.Request {
-	return c.Method.SetContext(c.CacheName.SetContext(req))
+	return c.Timeout.SetContext(c.Method.SetContext(c.CacheName.SetContext(req)))
 }
 
 func (c *Context) SetContext(req *http.Request) *http.Request {

--- a/plugins/traefik/override/surrogate/providers/common.go
+++ b/plugins/traefik/override/surrogate/providers/common.go
@@ -91,7 +91,6 @@ func (s *baseStorage) init(config configurationtypes.AbstractConfigurationInterf
 	}
 
 	s.dynamic = config.GetDefaultCache().GetCDN().Dynamic
-	s.logger = config.GetLogger()
 	s.keysRegexp = keysRegexp
 	s.mu = &sync.Mutex{}
 }
@@ -100,7 +99,7 @@ func (s *baseStorage) storeTag(tag string, cacheKey string, re *regexp.Regexp) {
 	if currentValue, b := s.Storage[tag]; s.dynamic || b {
 		if !re.MatchString(currentValue) {
 			s.mu.Lock()
-			s.logger.Sugar().Debugf("Store the tag %s", tag)
+			fmt.Printf("Store the tag %s", tag)
 			s.Storage[tag] = currentValue + souinStorageSeparator + cacheKey
 			s.mu.Unlock()
 		}

--- a/plugins/traefik/vendor/github.com/darkweak/souin/api/souin.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/api/souin.go
@@ -103,7 +103,7 @@ func (s *SouinAPI) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		} else if compile {
 			search := regexp.MustCompile(s.GetBasePath()+"/(.+)").FindAllStringSubmatch(r.RequestURI, -1)[0][1]
 			res, _ = json.Marshal(s.listKeys(search))
-			if res == nil {
+			if len(res) == 2 {
 				w.WriteHeader(http.StatusNotFound)
 			}
 		} else {

--- a/plugins/traefik/vendor/github.com/darkweak/souin/cache/surrogate/providers/common.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/cache/surrogate/providers/common.go
@@ -91,7 +91,6 @@ func (s *baseStorage) init(config configurationtypes.AbstractConfigurationInterf
 	}
 
 	s.dynamic = config.GetDefaultCache().GetCDN().Dynamic
-	s.logger = config.GetLogger()
 	s.keysRegexp = keysRegexp
 	s.mu = &sync.Mutex{}
 }
@@ -100,7 +99,7 @@ func (s *baseStorage) storeTag(tag string, cacheKey string, re *regexp.Regexp) {
 	if currentValue, b := s.Storage[tag]; s.dynamic || b {
 		if !re.MatchString(currentValue) {
 			s.mu.Lock()
-			s.logger.Sugar().Debugf("Store the tag %s", tag)
+			fmt.Printf("Store the tag %s", tag)
 			s.Storage[tag] = currentValue + souinStorageSeparator + cacheKey
 			s.mu.Unlock()
 		}

--- a/plugins/traefik/vendor/github.com/darkweak/souin/cache/surrogate/providers/types.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/cache/surrogate/providers/types.go
@@ -19,4 +19,5 @@ type SurrogateInterface interface {
 	ParseHeaders(string) []string
 	List() map[string]string
 	candidateStore(string) bool
+	Destruct() error
 }

--- a/plugins/traefik/vendor/github.com/darkweak/souin/configurationtypes/types.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/configurationtypes/types.go
@@ -90,6 +90,13 @@ type CacheProvider struct {
 	Configuration interface{} `json:"configuration" yaml:"configuration"`
 }
 
+// Timeout configuration to handle the cache provider and the
+// reverse-proxy timeout.
+type Timeout struct {
+	Backend Duration `json:"backend" yaml:"backend"`
+	Cache   Duration `json:"cache" yaml:"cache"`
+}
+
 // CDN config
 type CDN struct {
 	APIKey    string `json:"api_key,omitempty" yaml:"api_key,omitempty"`
@@ -123,8 +130,9 @@ type DefaultCache struct {
 	Olric               CacheProvider `json:"olric" yaml:"olric"`
 	Port                Port          `json:"port" yaml:"port"`
 	Regex               Regex         `json:"regex" yaml:"regex"`
-	TTL                 Duration      `json:"ttl" yaml:"ttl"`
 	Stale               Duration      `json:"stale" yaml:"stale"`
+	Timeout             Timeout       `json:"timeout" yaml:"timeout"`
+	TTL                 Duration      `json:"ttl" yaml:"ttl"`
 	DefaultCacheControl string        `json:"default_cache_control" yaml:"default_cache_control"`
 }
 
@@ -183,6 +191,11 @@ func (d *DefaultCache) GetRegex() Regex {
 	return d.Regex
 }
 
+// GetTimeout returns the backend and cache timeouts
+func (d *DefaultCache) GetTimeout() Timeout {
+	return d.Timeout
+}
+
 // GetTTL returns the default TTL
 func (d *DefaultCache) GetTTL() time.Duration {
 	return d.TTL.Duration
@@ -211,8 +224,9 @@ type DefaultCacheInterface interface {
 	GetHeaders() []string
 	GetKey() Key
 	GetRegex() Regex
-	GetTTL() time.Duration
 	GetStale() time.Duration
+	GetTimeout() Timeout
+	GetTTL() time.Duration
 	GetDefaultCacheControl() string
 }
 

--- a/plugins/traefik/vendor/github.com/darkweak/souin/context/timeout.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/context/timeout.go
@@ -1,0 +1,41 @@
+package context
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/darkweak/souin/configurationtypes"
+)
+
+const (
+	TimeoutCache  ctxKey = "TIMEOUT_CACHE"
+	TimeoutCancel ctxKey = "TIMEOUT_CANCEL"
+)
+
+const (
+	defaultTimeoutBackend = 10 * time.Second
+	defaultTimeoutCache   = 10 * time.Millisecond
+)
+
+type timeoutContext struct {
+	timeoutCache, timeoutBackend time.Duration
+}
+
+func (t *timeoutContext) SetupContext(c configurationtypes.AbstractConfigurationInterface) {
+	t.timeoutBackend = defaultTimeoutBackend
+	t.timeoutCache = defaultTimeoutCache
+	if c.GetDefaultCache().GetTimeout().Cache.Duration != 0 {
+		t.timeoutCache = c.GetDefaultCache().GetTimeout().Cache.Duration
+	}
+	if c.GetDefaultCache().GetTimeout().Backend.Duration != 0 {
+		t.timeoutBackend = c.GetDefaultCache().GetTimeout().Backend.Duration
+	}
+}
+
+func (t *timeoutContext) SetContext(req *http.Request) *http.Request {
+	ctx, cancel := context.WithTimeout(req.Context(), t.timeoutBackend)
+	return req.WithContext(context.WithValue(context.WithValue(ctx, TimeoutCancel, cancel), TimeoutCache, t.timeoutCache))
+}
+
+var _ ctx = (*cacheContext)(nil)

--- a/plugins/traefik/vendor/github.com/darkweak/souin/context/types.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/context/types.go
@@ -19,6 +19,7 @@ type (
 		GraphQL   ctx
 		Key       ctx
 		Method    ctx
+		Timeout   ctx
 	}
 )
 
@@ -28,6 +29,7 @@ func GetContext() *Context {
 		GraphQL:   &graphQLContext{},
 		Key:       &keyContext{},
 		Method:    &methodContext{},
+		Timeout:   &timeoutContext{},
 	}
 }
 
@@ -36,10 +38,11 @@ func (c *Context) Init(co configurationtypes.AbstractConfigurationInterface) {
 	c.GraphQL.SetupContext(co)
 	c.Key.SetupContext(co)
 	c.Method.SetupContext(co)
+	c.Timeout.SetupContext(co)
 }
 
 func (c *Context) SetBaseContext(req *http.Request) *http.Request {
-	return c.Method.SetContext(c.CacheName.SetContext(req))
+	return c.Timeout.SetContext(c.Method.SetContext(c.CacheName.SetContext(req)))
 }
 
 func (c *Context) SetContext(req *http.Request) *http.Request {

--- a/plugins/tyk/configuration.go
+++ b/plugins/tyk/configuration.go
@@ -166,6 +166,27 @@ func parseDefaultCache(dcConfiguration map[string]interface{}) *configurationtyp
 			if exclude != "" {
 				dc.Regex = configurationtypes.Regex{Exclude: exclude}
 			}
+		case "timeout":
+			timeout := configurationtypes.Timeout{}
+			for timeoutK, timeoutV := range defaultCacheV.(map[string]interface{}) {
+				switch timeoutK {
+				case "backend":
+					d := configurationtypes.Duration{}
+					ttl, err := time.ParseDuration(timeoutV.(string))
+					if err == nil {
+						d.Duration = ttl
+					}
+					timeout.Backend = d
+				case "cache":
+					d := configurationtypes.Duration{}
+					ttl, err := time.ParseDuration(timeoutV.(string))
+					if err == nil {
+						d.Duration = ttl
+					}
+					timeout.Cache = d
+				}
+			}
+			dc.Timeout = timeout
 		case "ttl":
 			ttl, err := time.ParseDuration(defaultCacheV.(string))
 			if err == nil {

--- a/plugins/tyk/configuration.go
+++ b/plugins/tyk/configuration.go
@@ -100,6 +100,8 @@ func parseDefaultCache(dcConfiguration map[string]interface{}) *configurationtyp
 				}
 			}
 			dc.Badger = provider
+		case "cache_name":
+			dc.CacheName, _ = defaultCacheV.(string)
 		case "cdn":
 			cdn := configurationtypes.CDN{}
 			for cdnConfigurationK, cdnConfigurationV := range defaultCacheV.(map[string]interface{}) {


### PR DESCRIPTION
Closes #239 

Add also
- [x] `/souin-api/souin/flush` endpoint to flush the whole cache and surrogate-keys list.
- [x] Update documentation.
- [x] Support the multi-provider. You'll be able to run different providers on different caddy directives in the same instance.
- [x] Add an incoming request debug message.
- [x] Add a response debug message even on a hit and miss.