### PR TITLE
feat: remove dep on `roadrunner-server/api`

### DIFF
--- a/plugins/roadrunner/configuration.go
+++ b/plugins/roadrunner/configuration.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/darkweak/souin/configurationtypes"
 	"github.com/darkweak/souin/plugins"
-	"github.com/roadrunner-server/api/v2/plugins/config"
 )
 
 const (
@@ -295,7 +294,7 @@ func parseSurrogateKeys(surrogates map[string]interface{}) map[string]configurat
 
 // ParseConfiguration parse the Roadrunner configuration into a valid HTTP
 // cache configuration object.
-func parseConfiguration(cfg config.Configurer) plugins.BaseConfiguration {
+func parseConfiguration(cfg Configurer) plugins.BaseConfiguration {
 	var configuration plugins.BaseConfiguration
 
 	for key, v := range cfg.Get(configurationKey).(map[string]interface{}) {

--- a/plugins/roadrunner/go.mod
+++ b/plugins/roadrunner/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/darkweak/souin v1.6.22
-	github.com/roadrunner-server/api/v2 v2.23.0
 	github.com/roadrunner-server/errors v1.2.0
 	go.uber.org/zap v1.23.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/plugins/roadrunner/go.sum
+++ b/plugins/roadrunner/go.sum
@@ -324,8 +324,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/roadrunner-server/api/v2 v2.23.0 h1:FCpVZWl7fZZqBdD/Z4HCVgQ+vKbqARneji20mp3iqDM=
-github.com/roadrunner-server/api/v2 v2.23.0/go.mod h1:UrOUfDFw0927h/PWv7f8PPcwfdHkwf8txWbmqszL7UA=
 github.com/roadrunner-server/errors v1.2.0 h1:qBmNXt8Iex9QnYTjCkbJKsBZu2EtYkQCM06GUDcQBbI=
 github.com/roadrunner-server/errors v1.2.0/go.mod h1:z0ECxZp/dDa5RahtMcy4mBIavVxiZ9vwE5kByl7kFtY=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/plugins/roadrunner/httpcache.go
+++ b/plugins/roadrunner/httpcache.go
@@ -11,7 +11,6 @@ import (
 	"github.com/darkweak/souin/cache/coalescing"
 	"github.com/darkweak/souin/plugins"
 	"github.com/darkweak/souin/rfc"
-	"github.com/roadrunner-server/api/v2/plugins/config"
 	"github.com/roadrunner-server/errors"
 	"go.uber.org/zap"
 )
@@ -21,7 +20,17 @@ const (
 )
 
 type (
-	key    string
+	key string
+
+	// Configurer interface used to parse yaml configuration.
+	// Implementation will be provided by the RoadRunner automatically via Init method.
+	Configurer interface {
+		// Get used to get config section
+		Get(name string) any
+		// Has checks if config section exists.
+		Has(name string) bool
+	}
+
 	Plugin struct {
 		plugins.SouinBasePlugin
 		Configuration *plugins.BaseConfiguration
@@ -39,10 +48,10 @@ func (p *Plugin) Name() string {
 	return "cache"
 }
 
-// Init, allows the user to set up an HTTP cache system,
+// Init allows the user to set up an HTTP cache system,
 // RFC-7234 compliant and supports the tag based cache purge,
 // distributed and not-distributed storage, key generation tweaking.
-func (p *Plugin) Init(cfg config.Configurer, log *zap.Logger) error {
+func (p *Plugin) Init(cfg Configurer, log *zap.Logger) error {
 	const op = errors.Op("httpcache_middleware_init")
 	if !cfg.Has(configurationKey) {
 		return errors.E(op, errors.Disabled)


### PR DESCRIPTION
# Reason for This PR

- RR container (endure) may detect plugins that implement a particular interface. Thus there is no need to depend on `api` anymore, the interface might be declared in the plugin (where it actually used, Go-way 😄).

## Description of Changes

- Remove `roadrunner-server/api` dep.
- Update error handling in the tests.
- Declare the local interface:
```go
	// Configurer interface used to parse yaml configuration.
	// Implementation will be provided by the RoadRunner automatically via Init method.
	type Configurer interface {
		// Get used to get config section
		Get(name string) any
		// Has checks if config section exists.
		Has(name string) bool
	}
```

If you need another (additional) method, just check the structure `Plugin` (as the implementation): https://github.com/roadrunner-server/config/blob/master/plugin.go, and add the needed method to the local interface 😄 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.