### PR TITLE
Disable query string in key

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ cache_keys:
     disable_body: true # Prevent the body from being used in the cache key
     disable_host: true # Prevent the host from being used in the cache key
     disable_method: true # Prevent the method from being used in the cache key
+    disable_query: true # Prevent the query string from being used in the cache key
     headers: # Add headers to the key
       - Authorization # Add the header value in the key
       - Content-Type # Add the header value in the key
@@ -102,6 +103,7 @@ default_cache:
     disable_body: true # Prevent the body from being used in the cache key
     disable_host: true # Prevent the host from being used in the cache key
     disable_method: true # Prevent the method from being used in the cache key
+    disable_query: true # Prevent the query string from being used in the cache key
     headers: # Add headers to the key
       - Authorization # Add the header value in the key
       - Content-Type # Add the header value in the key
@@ -165,6 +167,7 @@ surrogate_keys:
 | `cache_keys.{your regexp}.disable_body`           | Disable the body part in the key matching the regexp (GraphQL context)                                                                      | `true`<br/><br/>`(default: false)`                                                                                        |
 | `cache_keys.{your regexp}.disable_host`           | Disable the host part in the key matching the regexp                                                                                        | `true`<br/><br/>`(default: false)`                                                                                        |
 | `cache_keys.{your regexp}.disable_method`         | Disable the method part in the key matching the regexp                                                                                      | `true`<br/><br/>`(default: false)`                                                                                        |
+| `cache_keys.{your regexp}.disable_query`          | Disable the query string part in the key matching the regexp                                                                                | `true`<br/><br/>`(default: false)`                                                                                        |
 | `cache_keys.{your regexp}.headers`                | Add headers to the key matching the regexp                                                                                                  | `- Authorization`<br/><br/>`- Content-Type`<br/><br/>`- X-Additional-Header`                                              |
 | `cache_keys.{your regexp}.hide`                   | Prevent the key from being exposed in the `Cache-Status` HTTP response header                                                               | `true`<br/><br/>`(default: false)`                                                                                        |
 | `cdn`                                             | The CDN management, if you use any cdn to proxy your requests Souin will handle that                                                        |                                                                                                                           |
@@ -189,6 +192,7 @@ surrogate_keys:
 | `default_cache.key.disable_body`                  | Disable the body part in the key (GraphQL context)                                                                                          | `true`<br/><br/>`(default: false)`                                                                                        |
 | `default_cache.key.disable_host`                  | Disable the host part in the key                                                                                                            | `true`<br/><br/>`(default: false)`                                                                                        |
 | `default_cache.key.disable_method`                | Disable the method part in the key                                                                                                          | `true`<br/><br/>`(default: false)`                                                                                        |
+| `default_cache.key.disable_query`                 | Disable the query string part in the key                                                                                                    | `true`<br/><br/>`(default: false)`                                                                                        |
 | `default_cache.key.headers`                       | Add headers to the key matching the regexp                                                                                                  | `- Authorization`<br/><br/>`- Content-Type`<br/><br/>`- X-Additional-Header`                                              |
 | `default_cache.key.hide`                          | Prevent the key from being exposed in the `Cache-Status` HTTP response header                                                               | `true`<br/><br/>`(default: false)`                                                                                        |
 | `default_cache.nuts`                              | Configure the Nuts cache storage                                                                                                            |                                                                                                                           |
@@ -457,6 +461,7 @@ There is the fully configuration below
                 disable_body
                 disable_host
                 disable_method
+                disable_query
                 headers X-Token Authorization
                 hide
             }
@@ -476,6 +481,7 @@ There is the fully configuration below
             disable_body
             disable_host
             disable_method
+            disable_query
             headers Content-Type Authorization
         }
         log_level debug

--- a/configurationtypes/types.go
+++ b/configurationtypes/types.go
@@ -115,6 +115,7 @@ type Key struct {
 	DisableBody   bool     `json:"disable_body" yaml:"disable_body"`
 	DisableHost   bool     `json:"disable_host" yaml:"disable_host"`
 	DisableMethod bool     `json:"disable_method" yaml:"disable_method"`
+	DisableQuery  bool     `json:"disable_query" yaml:"disable_query"`
 	Hide          bool     `json:"hide" yaml:"hide"`
 	Headers       []string `json:"headers" yaml:"headers"`
 }

--- a/context/key.go
+++ b/context/key.go
@@ -18,6 +18,7 @@ type keyContext struct {
 	disable_body   bool
 	disable_host   bool
 	disable_method bool
+	disable_query  bool
 	displayable    bool
 	headers        []string
 	overrides      map[*regexp.Regexp]keyContext
@@ -38,6 +39,7 @@ func (g *keyContext) SetupContext(c configurationtypes.AbstractConfigurationInte
 			disable_body:   v.DisableBody,
 			disable_host:   v.DisableHost,
 			disable_method: v.DisableMethod,
+			disable_query:  v.DisableQuery,
 			displayable:    v.Hide,
 			headers:        v.Headers,
 		}
@@ -57,6 +59,10 @@ func (g *keyContext) SetContext(req *http.Request) *http.Request {
 	method := ""
 	headerValues := ""
 	displayable := g.displayable
+
+	if !g.disable_query && len(req.URL.RawQuery) > 0 {
+		key += "?" + req.URL.RawQuery
+	}
 
 	if !g.disable_body {
 		body = req.Context().Value(HashBody).(string)

--- a/context/key.go
+++ b/context/key.go
@@ -45,7 +45,7 @@ func (g *keyContext) SetupContext(c configurationtypes.AbstractConfigurationInte
 }
 
 func (g *keyContext) SetContext(req *http.Request) *http.Request {
-	key := req.URL.RequestURI()
+	key := req.URL.Path
 	var headers []string
 
 	scheme := "http-"

--- a/context/key_test.go
+++ b/context/key_test.go
@@ -61,8 +61,8 @@ func Test_KeyContext_SetContext(t *testing.T) {
 	ctx := keyContext{}
 	req := httptest.NewRequest(http.MethodGet, "http://domain.com", nil)
 	req = ctx.SetContext(req.WithContext(context.WithValue(req.Context(), HashBody, "-with_the_hash")))
-	if req.Context().Value(Key).(string) != "GET-http-domain.com-/-with_the_hash" {
-		t.Errorf("The Key context must be equal to GET-http-domain.com-/-with_the_hash, %s given.", req.Context().Value(Key).(string))
+	if req.Context().Value(Key).(string) != "GET-http-domain.com--with_the_hash" {
+		t.Errorf("The Key context must be equal to GET-http-domain.com--with_the_hash, %s given.", req.Context().Value(Key).(string))
 	}
 
 	m := make(map[*regexp.Regexp]keyContext)
@@ -101,4 +101,28 @@ func Test_KeyContext_SetContext(t *testing.T) {
 	if req4.Context().Value(Key).(string) != "http-domain.com-/something" {
 		t.Errorf("The Key context must be equal to http-domain.com-/something, %s given.", req4.Context().Value(Key).(string))
 	}
+
+	// Added tests for disable_query
+	ctx4 := keyContext{
+		disable_query:  true,
+		disable_method: false,
+		disable_host:   false,
+	}
+	req5 := httptest.NewRequest(http.MethodGet, "http://domain.com/matched?query=string", nil)
+	req5 = ctx4.SetContext(req5.WithContext(context.WithValue(req5.Context(), HashBody, "")))
+	if req5.Context().Value(Key).(string) != "GET-http-domain.com-/matched" {
+		t.Errorf("The Key context must be equal to GET-http-domain.com-/matched, %s given.", req5.Context().Value(Key).(string))
+	}
+
+	ctx5 := keyContext{
+		disable_query:  false,
+		disable_method: false,
+		disable_host:   false,
+	}
+	req6 := httptest.NewRequest(http.MethodGet, "http://domain.com/matched?query=string", nil)
+	req6 = ctx5.SetContext(req6.WithContext(context.WithValue(req6.Context(), HashBody, "")))
+	if req6.Context().Value(Key).(string) != "GET-http-domain.com-/matched?query=string" {
+		t.Errorf("The Key context must be equal to GET-http-domain.com-/matched?query=string, %s given.", req6.Context().Value(Key).(string))
+	}
+
 }

--- a/context/types_test.go
+++ b/context/types_test.go
@@ -38,8 +38,8 @@ func Test_Context_SetContext(t *testing.T) {
 	co.Init(&c)
 	req := httptest.NewRequest(http.MethodGet, "http://domain.com", nil)
 	req = co.SetContext(req)
-	if req.Context().Value(Key) != "GET-http-domain.com-/" {
-		t.Errorf("The Key context must be equal to GET-http-domain.com-/, %s given.", req.Context().Value(Key))
+	if req.Context().Value(Key) != "GET-http-domain.com-" {
+		t.Errorf("The Key context must be equal to GET-http-domain.com-, %s given.", req.Context().Value(Key))
 	}
 	if req.Context().Value(GraphQL) != false {
 		t.Error("The GraphQL context must be false.")

--- a/plugins/caddy/configuration.go
+++ b/plugins/caddy/configuration.go
@@ -331,6 +331,8 @@ func parseConfiguration(cfg *Configuration, h *caddyfile.Dispenser, isBlocking b
 							ck.DisableHost = true
 						case "disable_method":
 							ck.DisableMethod = true
+						case "disable_query":
+							ck.DisableQuery = true
 						case "hide":
 							ck.Hide = true
 						case "headers":
@@ -395,6 +397,8 @@ func parseConfiguration(cfg *Configuration, h *caddyfile.Dispenser, isBlocking b
 						config_key.DisableHost = true
 					case "disable_method":
 						config_key.DisableMethod = true
+					case "disable_query":
+						config_key.DisableQuery = true
 					case "hide":
 						config_key.Hide = true
 					case "headers":

--- a/plugins/kratos/configuration.go
+++ b/plugins/kratos/configuration.go
@@ -101,6 +101,8 @@ func parseCacheKeys(ccConfiguration map[string]config.Value) map[configurationty
 				ck.DisableHost = true
 			case "disable_method":
 				ck.DisableMethod = true
+			case "disable_query":
+				ck.DisableQuery = true
 			case "hide":
 				ck.Hide = true
 			case "headers":

--- a/plugins/souin/agnostic/configuration_parser.go
+++ b/plugins/souin/agnostic/configuration_parser.go
@@ -67,6 +67,8 @@ func parseCacheKeys(ccConfiguration map[string]interface{}) map[configurationtyp
 				ck.DisableHost = true
 			case "disable_method":
 				ck.DisableMethod = true
+			case "disable_query":
+				ck.DisableQuery = true
 			case "hide":
 				ck.Hide = true
 			case "headers":


### PR DESCRIPTION
Adds the parameter "disable_query", which disable the use of query string in cache key name.