### PR TITLE
fix(traefik): parse "mode" configuration parameter in Traefik plugin

### DIFF
--- a/plugins/traefik/main.go
+++ b/plugins/traefik/main.go
@@ -159,6 +159,8 @@ func parseConfiguration(c map[string]interface{}) Configuration {
 					dc.Headers = parseStringSlice(defaultCacheV)
 				case "key":
 					dc.Key = configCacheKey(defaultCacheV.(map[string]interface{}))
+				case "mode":
+					dc.Mode = defaultCacheV.(string)
 				case "regex":
 					exclude := defaultCacheV.(map[string]interface{})["exclude"].(string)
 					if exclude != "" {


### PR DESCRIPTION
In the Traefik plugin, the `default_cache.mode` parameter was not being read, so Souin was always running in **strict** mode.