### PR TITLE
fix(rfc): Age header update

### DIFF
--- a/pkg/rfc/age.go
+++ b/pkg/rfc/age.go
@@ -20,6 +20,10 @@ func validateMaxAgeCachedResponse(res *http.Response, maxAge int, addTime int) *
 func ValidateMaxAgeCachedResponse(co *cacheobject.RequestCacheDirectives, res *http.Response) *http.Response {
 	responseCc, _ := cacheobject.ParseResponseCacheControl(res.Header.Get("Cache-Control"))
 	ma := co.MaxAge
+	if responseCc.MaxAge > -1 {
+		ma = responseCc.MaxAge
+	}
+	// s-maxage overwrites max-age in the response if available together
 	if responseCc.SMaxAge > -1 {
 		ma = responseCc.SMaxAge
 	}

--- a/pkg/rfc/cache_status.go
+++ b/pkg/rfc/cache_status.go
@@ -105,8 +105,18 @@ func manageAge(h *http.Header, ttl time.Duration, cacheName, key string) {
 		apparentAge = 0
 	}
 
+	var oldAge int
+	{
+		var err error
+		oldAgeString := h.Get("Age")
+		oldAge, err = strconv.Atoi(oldAgeString)
+		if err != nil {
+			oldAge = 0
+		}
+	}
+
 	cage := int(math.Ceil(apparentAge.Seconds()))
-	age := strconv.Itoa(cage)
+	age := strconv.Itoa(oldAge + cage)
 	h.Set("Age", age)
 	ttlValue := strconv.Itoa(int(ttl.Seconds()) - cage)
 	h.Set("Cache-Status", cacheName+"; hit; ttl="+ttlValue+"; key="+key)


### PR DESCRIPTION
Fixes following test from [cache-tests.fyi](https://cache-tests.fyi): `freshness-max-age-age`, [freshness-max-age-s-maxage-shared-longer-multiple](url). Unlocks the whole "Age Parsing" section of the test suite (see [here](https://cache-tests.fyi/#age-parse)).