### PR TITLE
fix(chore): Wrong panic in singleflight

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -320,7 +320,7 @@ func (s *SouinBaseHandler) Upstream(
 		if r := recover(); r != nil {
 			err := r.(error)
 			if errors.Is(err, http.ErrAbortHandler) {
-				recoveredFromErr = errors.Unwrap(err)
+				recoveredFromErr = http.ErrAbortHandler
 			} else {
 				panic(err)
 			}

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -313,6 +313,19 @@ func (s *SouinBaseHandler) Upstream(
 	s.Configuration.GetLogger().Sugar().Debug("Request the upstream server")
 	prometheus.Increment(prometheus.RequestCounter)
 
+	var recoveredFromErr error = nil
+	defer func() {
+		// In case of "http.ErrAbortHandler" panic,
+		// prevent singleflight from wrapping it into "singleflight.panicError".
+		if r := recover(); r != nil {
+			err := r.(error)
+			if errors.Is(err, http.ErrAbortHandler) {
+				recoveredFromErr = errors.Unwrap(err)
+			} else {
+				panic(err)
+			}
+		}
+	}()
 	sfValue, err, shared := s.singleflightPool.Do(cachedKey, func() (interface{}, error) {
 		if e := next(customWriter, rq); e != nil {
 			s.Configuration.GetLogger().Sugar().Warnf("%#v", e)
@@ -345,7 +358,9 @@ func (s *SouinBaseHandler) Upstream(
 			code:           statusCode,
 		}, err
 	})
-
+	if recoveredFromErr != nil {
+		panic(recoveredFromErr)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Proposal for a fix for the incorrect panic with `singleflight.panicError` when `http.ErrAbortHandler` in expected by `net/http` (see [here](https://github.com/golang/go/blob/8db131082d08e497fd8e9383d0ff7715e1bef478/src/net/http/server.go#L1895)) and `http2` (see [here](https://github.com/golang/net/blob/689bbc7005f6bbf9fac1a8333bf03436fa4b4b2a/http2/server.go#L2358)).

References:
- `http.ErrAbortHandler` panic is triggered by Caddy [here](https://github.com/caddyserver/caddy/blob/cb86319bd50322d4ac9e730b2fc5639daa24b82a/modules/caddyhttp/reverseproxy/reverseproxy.go#L974C3-L974C30).