### PR TITLE
caddy: depend on Souin@6a3a38592bc2

### DIFF
--- a/plugins/caddy/go.mod
+++ b/plugins/caddy/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/buraksezer/olric v0.5.4
 	github.com/caddyserver/caddy/v2 v2.7.6
-	github.com/darkweak/souin v1.6.45
+	github.com/darkweak/souin v1.6.46-0.20240209164332-6a3a38592bc2
 	go.uber.org/zap v1.26.0
 )
 

--- a/plugins/caddy/go.sum
+++ b/plugins/caddy/go.sum
@@ -136,6 +136,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/darkweak/go-esi v0.0.5 h1:b9LHI8Tz46R+i6p8avKPHAIBRQUCZDebNmKm5w/Zrns=
 github.com/darkweak/go-esi v0.0.5/go.mod h1:koCJqwum1u6mslyZuq/Phm6hfG1K3ZK5Y7jrUBTH654=
+github.com/darkweak/souin v1.6.46-0.20240209164332-6a3a38592bc2 h1:5dnlbtV5t+UhKIUeBqCygvdztSNOIICSv7xkCPQQD4Q=
+github.com/darkweak/souin v1.6.46-0.20240209164332-6a3a38592bc2/go.mod h1:zAkfDgc615wNJUkkNvoAVanT+oYXdMZfoWgok8MoHW4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
There were changes in Souin after v1.6.45 which the Caddy plugin depends on, namely the move of the `types` package into `pkg/storage/types`. Trying to build Caddy with the caddy plugin in this repo always fails because the Go module resolver sees the latest tagged Souin at the time (v1.6.45) which doesn't have the package `pkg/storage/types`.

The Go module resolver won't upgrade Souin because the plugin depends on a specific tag as minimum and there's no need to upgrade. Given that the plugin depends on a specific package that only exists after `v1.6.45`, then the plugin should depend on at least the particular commit that includes it. Depending on  HEAD (6a3a38592bc2 at this moment) resolves the issue.

For readers facing this before the PR is merged, here's the solution to build it with xcaddy:

```
xcaddy build --with github.com/darkweak/souin@master --with github.com/darkweak/souin/plugins/caddy
```

The order of `--with` modules happens to be important in this case because of reasons.