### PR TITLE
feat(chore): storage handle fresh/stale at once with multi layer storage

### DIFF
--- a/pkg/rfc/revalidation.go
+++ b/pkg/rfc/revalidation.go
@@ -59,7 +59,12 @@ func ParseRequest(req *http.Request) *Revalidator {
 }
 
 func ValidateETag(res *http.Response, validator *Revalidator) {
-	validator.ResponseETag = res.Header.Get("ETag")
+	ValidateETagFromHeader(res.Header.Get("ETag"), validator)
+
+}
+
+func ValidateETagFromHeader(etag string, validator *Revalidator) {
+	validator.ResponseETag = etag
 	validator.NeedRevalidation = validator.NeedRevalidation || validator.ResponseETag != ""
 	validator.Matched = validator.ResponseETag == "" || (validator.ResponseETag != "" && len(validator.RequestETags) == 0)
 

--- a/pkg/storage/badgerProvider.go
+++ b/pkg/storage/badgerProvider.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"regexp"
 	"strings"
@@ -198,6 +199,78 @@ func (provider *Badger) Prefix(key string, req *http.Request, validator *rfc.Rev
 	})
 
 	return result
+}
+
+// GetMultiLevel tries to load the key and check if one of linked keys is a fresh/stale candidate.
+func (provider *Badger) GetMultiLevel(key string, req *http.Request, validator *rfc.Revalidator) (fresh *http.Response, stale *http.Response) {
+	var resultFresh *http.Response
+	var resultStale *http.Response
+
+	_ = provider.DB.View(func(tx *badger.Txn) error {
+		i, e := tx.Get([]byte(mappingKeyPrefix + key))
+		if e != nil && !errors.Is(e, badger.ErrKeyNotFound) {
+			return e
+		}
+
+		var val []byte
+		if i != nil {
+			_ = i.Value(func(b []byte) error {
+				val = b
+
+				return nil
+			})
+		}
+		resultFresh, resultStale, e = mappingElection(provider, val, req, validator, provider.logger)
+
+		return e
+	})
+
+	return resultFresh, resultStale
+}
+
+// SetMultiLevel tries to store the keywith the given value and update the mapping key to store metadata.
+func (provider *Badger) SetMultiLevel(baseKey, key string, value []byte, variedHeaders http.Header, etag string, duration time.Duration) error {
+	now := time.Now()
+
+	err := provider.DB.Update(func(tx *badger.Txn) error {
+		var e error
+		e = tx.SetEntry(badger.NewEntry([]byte(key), value).WithTTL(duration))
+		if e != nil {
+			provider.logger.Sugar().Errorf("Impossible to set the key %s into Badger, %v", key, e)
+			return e
+		}
+
+		mappingKey := mappingKeyPrefix + baseKey
+		item, e := tx.Get([]byte(mappingKey))
+		if e != nil && !errors.Is(e, badger.ErrKeyNotFound) {
+			provider.logger.Sugar().Errorf("Impossible to get the base key %s in Badger, %v", mappingKey, e)
+			return e
+		}
+
+		var val []byte
+		if item != nil {
+			_ = item.Value(func(b []byte) error {
+				val = b
+
+				return nil
+			})
+		}
+
+		val, e = mappingUpdater(key, val, provider.logger, now, now.Add(duration), now.Add(duration+provider.stale), variedHeaders, etag)
+		if e != nil {
+			return e
+		}
+
+		provider.logger.Sugar().Errorf("Store the new mapping for the key %s in Badger, %v", key, string(val))
+
+		return tx.Set([]byte(mappingKey), val)
+	})
+
+	if err != nil {
+		provider.logger.Sugar().Errorf("Impossible to set value into Badger, %v", err)
+	}
+
+	return err
 }
 
 // Set method will store the response in Badger provider

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -8,6 +8,18 @@ import (
 	"github.com/darkweak/souin/pkg/rfc"
 )
 
+type KeyIndex struct {
+	StoredAt      time.Time   `json:"stored"`
+	FreshTime     time.Time   `json:"fresh"`
+	StaleTime     time.Time   `json:"stale"`
+	VariedHeaders http.Header `json:"varied"`
+	Etag          string      `json:"etag"`
+}
+
+type StorageMapper struct {
+	Mapping map[string]KeyIndex `json:"mapping"`
+}
+
 type Storer interface {
 	MapKeys(prefix string) map[string]string
 	ListKeys() []string
@@ -19,4 +31,8 @@ type Storer interface {
 	Init() error
 	Name() string
 	Reset() error
+
+	// Multi level storer to handle fresh/stale at once
+	GetMultiLevel(key string, req *http.Request, validator *rfc.Revalidator) (fresh *http.Response, stale *http.Response)
+	SetMultiLevel(baseKey, key string, value []byte, variedHeaders http.Header, etag string, duration time.Duration) error
 }


### PR DESCRIPTION
This PR add the multi layer storage.
Actually Souin stores both fresh and stale response. With this PR it will store only one response but add a mapping layer.  
It also resolve the vary checker issue. In the mapping we store
* Fresh time
* Stale time
* Varied headers
* Etag value
* Stored at

The next improvement will be the stale/fresh election using the `stored at` property and the max-age client directive. The election will be faster than the existing one because we don't have to parse the stored response anymore to check the vary/etag.

TODO:
- [x] Dual layer storage
- [x] Vary elector
- [x] ETag checker
- [ ] Stored at freshness election