### PR TITLE
fix(plugins): Caddy config cache_keys json parse error

### DIFF
--- a/configurationtypes/types.go
+++ b/configurationtypes/types.go
@@ -21,8 +21,6 @@ func (c *CacheKeys) parseJSON(rootDecoder *json.Decoder) {
 	var err error
 
 	_, _ = rootDecoder.Token()
-	_, _ = rootDecoder.Token()
-	_, _ = rootDecoder.Token()
 
 	for err == nil {
 		token, err = rootDecoder.Token()

--- a/plugins/caddy/httpcache_test.go
+++ b/plugins/caddy/httpcache_test.go
@@ -114,6 +114,39 @@ func TestQueryString(t *testing.T) {
 	}
 }
 
+func TestCacheKeys(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	tester.InitServer(`
+	{
+		admin localhost:2999
+		order cache before rewrite
+		http_port     9080
+		https_port    9443
+		cache 
+	}
+	localhost:9080 {
+		route /query-string {
+			cache {
+				cache_keys {
+					query= {
+						disable_query
+					}
+				}
+			}
+			respond "Hello, query string!"
+		}
+	}`, "caddyfile")
+
+	resp1, _ := tester.AssertGetResponse(`http://localhost:9080/query-string?query=string`, 200, "Hello, query string!")
+	if resp1.Header.Get("Cache-Status") != "Souin; fwd=uri-miss; stored; key=GET-http-localhost:9080-/query-string" {
+		t.Errorf("unexpected Cache-Status header %v", resp1.Header)
+	}
+	resp2, _ := tester.AssertGetResponse(`http://localhost:9080/query-string?foo=bar`, 200, "Hello, query string!")
+	if resp2.Header.Get("Cache-Status") != "Souin; fwd=uri-miss; stored; key=GET-http-localhost:9080-/query-string?foo=bar" {
+		t.Errorf("unexpected Cache-Status header %v", resp2.Header)
+	}
+}
+
 func TestMaxAge(t *testing.T) {
 	tester := caddytest.NewTester(t)
 	tester.InitServer(`


### PR DESCRIPTION
I'm not sure, how the `cache_keys` with regexp should exactly work by specification, but the following example in the `Caddyfile` did not work.
```
    cache {
        cache_keys {
            /.+ {
                headers Authorization
            }
        }
    }
```
The json parser of the CacheKeys struct shifted directives up and the regexp become the directive form inside the block.