### PR TITLE
ci: improve action name for readability

### DIFF
--- a/.github/workflows/plugin_template.yml
+++ b/.github/workflows/plugin_template.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   plugin-test:
-    name: Check that Souin build as ${{ inputs.CAPITALIZED_NAME }} middleware
+    name: ${{ inputs.CAPITALIZED_NAME }}
     runs-on: ubuntu-latest
     env: 
       GO_VERSION: ${{ inputs.GO_VERSION }}

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-caddy-validator:
-    name: Check that Souin build as caddy module
+    name: Caddy
     runs-on: ubuntu-latest
     services:
       redis:
@@ -153,7 +153,6 @@ jobs:
             title: 'cache-tests suite result'
 
   build-beego-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -161,7 +160,6 @@ jobs:
       LOWER_NAME: beego
       GO_VERSION: '1.21'
   build-chi-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -169,7 +167,6 @@ jobs:
       LOWER_NAME: chi
       GO_VERSION: '1.21'
   build-dotweb-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -177,7 +174,6 @@ jobs:
       LOWER_NAME: dotweb
       GO_VERSION: '1.21'
   build-echo-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -185,7 +181,6 @@ jobs:
       LOWER_NAME: echo
       GO_VERSION: '1.21'
   build-fiber-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -193,7 +188,6 @@ jobs:
       LOWER_NAME: fiber
       GO_VERSION: '1.21'
   build-gin-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -201,7 +195,6 @@ jobs:
       LOWER_NAME: gin
       GO_VERSION: '1.21'
   build-goa-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -209,7 +202,6 @@ jobs:
       LOWER_NAME: goa
       GO_VERSION: '1.21'
   build-kratos-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -217,7 +209,6 @@ jobs:
       LOWER_NAME: kratos
       GO_VERSION: '1.21'
   build-roadrunner-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -225,7 +216,6 @@ jobs:
       LOWER_NAME: roadrunner
       GO_VERSION: '1.21'
   build-souin-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -233,7 +223,6 @@ jobs:
       LOWER_NAME: souin
       GO_VERSION: '1.21'
   build-traefik-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -241,7 +230,6 @@ jobs:
       LOWER_NAME: traefik
       GO_VERSION: '1.21'
   build-tyk-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:
@@ -249,7 +237,6 @@ jobs:
       LOWER_NAME: tyk
       GO_VERSION: '1.21'
   build-webgo-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:

--- a/.github/workflows/workflow_plugins_generator.sh
+++ b/.github/workflows/workflow_plugins_generator.sh
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-caddy-validator:
-    name: Check that Souin build as caddy module
+    name: Caddy
     runs-on: ubuntu-latest
     services:
       redis:
@@ -168,7 +168,6 @@ for i in ${!plugins[@]}; do
   capitalized="$(tr '[:lower:]' '[:upper:]' <<< ${lower:0:1})${lower:1}"
   IFS= read -d '' tpl <<EOF
   build-$lower-validator:
-    name: Check that Souin build as middleware
     uses: ./.github/workflows/plugin_template.yml
     secrets: inherit
     with:


### PR DESCRIPTION
I was watching the Actions run on the PRs and noticed it's hard to read the Action name due to how long the name of the action as it includes the description in addition to the plugin name. This should make it better.