### PR TITLE
fix(chore): allow to delete keys by regex

### DIFF
--- a/pkg/api/souin.go
+++ b/pkg/api/souin.go
@@ -93,9 +93,15 @@ func (s *SouinAPI) BulkDelete(key string, purge bool) {
 }
 
 // Delete will delete a record into the provider cache system and will update the Souin API if enabled
+// The key can be a regexp to delete multiple items
 func (s *SouinAPI) Delete(key string) {
 	for _, current := range s.storers {
-		current.Delete(key)
+		_, err := regexp.Compile(key)
+		if err != nil {
+			current.DeleteMany(key)
+		} else {
+			current.Delete(key)
+		}
 	}
 }
 

--- a/pkg/api/souin.go
+++ b/pkg/api/souin.go
@@ -95,8 +95,8 @@ func (s *SouinAPI) BulkDelete(key string, purge bool) {
 // Delete will delete a record into the provider cache system and will update the Souin API if enabled
 // The key can be a regexp to delete multiple items
 func (s *SouinAPI) Delete(key string) {
+	_, err := regexp.Compile(key)
 	for _, current := range s.storers {
-		_, err := regexp.Compile(key)
 		if err != nil {
 			current.DeleteMany(key)
 		} else {


### PR DESCRIPTION
After providing some testing of removing keys by regex from Redis storage using Souin API, I saw that keys still exist, and nothing happened after calling the `PURGE` request with regex. But the `PURGE` request to the `/flush` endpoint works.

So I debugged the purge method and found that it deleted keys only by providing a whole key ID. So I added checking if the key is the regex than`Delete` method in Souin API should call `DeleteMany` instead of `Delete.`

Related to #417 