### PR TITLE
fix(middleware): avoid sending empty Content-Length

### DIFF
--- a/pkg/middleware/writer.go
+++ b/pkg/middleware/writer.go
@@ -82,7 +82,10 @@ func (r *CustomWriter) Write(b []byte) (int, error) {
 // Send delays the response to handle Cache-Status
 func (r *CustomWriter) Send() (int, error) {
 	defer r.Buf.Reset()
-	r.Header().Set("Content-Length", r.Header().Get(rfc.StoredLengthHeader))
+	storedLength := r.Header().Get(rfc.StoredLengthHeader)
+	if storedLength != "" {
+		r.Header().Set("Content-Length", storedLength)
+	}
 	b := esi.Parse(r.Buf.Bytes(), r.Req)
 	if len(b) != 0 {
 		r.Header().Set("Content-Length", strconv.Itoa(len(b)))


### PR DESCRIPTION
Fix https://github.com/caddyserver/cache-handler/issues/104

Tested with

```
FROM caddy:2.8.4-builder AS builder
RUN xcaddy build --with github.com/darkweak/souin=github.com/imlonghao/souin@fix-empty-response --with github.com/darkweak/souin/plugins/caddy

FROM caddy:2.8.4
COPY --from=builder /usr/bin/caddy /usr/bin/caddy
```