### PR TITLE
fix(chore): allow to delete keys by regex

### DIFF
--- a/pkg/api/souin.go
+++ b/pkg/api/souin.go
@@ -105,8 +105,13 @@ func (s *SouinAPI) BulkDelete(key string, purge bool) {
 // Delete will delete a record into the provider cache system and will update the Souin API if enabled
 // The key can be a regexp to delete multiple items
 func (s *SouinAPI) Delete(key string) {
+	_, err := regexp.Compile(key)
 	for _, current := range s.storers {
-		current.Delete(key)
+		if err != nil {
+			current.DeleteMany(key)
+		} else {
+			current.Delete(key)
+		}
 	}
 }
 


### PR DESCRIPTION
Seems like after releasing `1.7.0` version changes from [this PR](https://github.com/darkweak/souin/pull/526) are missing
Deleting keys by regexp is not working again