### PR TITLE
Add missing configuration options to cdn directive

### DIFF
--- a/plugins/caddy/configuration.go
+++ b/plugins/caddy/configuration.go
@@ -441,14 +441,20 @@ func parseConfiguration(cfg *Configuration, h *caddyfile.Dispenser, isGlobal boo
 						if len(args) > 0 {
 							cdn.Dynamic, _ = strconv.ParseBool(args[0])
 						}
+					case "email":
+						cdn.Email = h.RemainingArgs()[0]
 					case "hostname":
 						cdn.Hostname = h.RemainingArgs()[0]
 					case "network":
 						cdn.Network = h.RemainingArgs()[0]
 					case "provider":
 						cdn.Provider = h.RemainingArgs()[0]
+					case "service_id":
+						cdn.ServiceID = h.RemainingArgs()[0]
 					case "strategy":
 						cdn.Strategy = h.RemainingArgs()[0]
+					case "zone_id":
+						cdn.ZoneID = h.RemainingArgs()[0]
 					default:
 						return h.Errf("unsupported cdn directive: %s", directive)
 					}


### PR DESCRIPTION
Some options for CDN cannot be set from caddy directives due to some missing mapping/configuration.

This pull request adds a directive for each that is missing and documented - so is a fix.

Thanks for al your work!

Ps the first lines of Go I've every written.