### PR TITLE
feat(core): upstream select it's own storage

### DIFF
--- a/pkg/middleware/writer.go
+++ b/pkg/middleware/writer.go
@@ -24,7 +24,7 @@ func NewCustomWriter(rq *http.Request, rw http.ResponseWriter, b *bytes.Buffer) 
 		Req:        rq,
 		Rw:         rw,
 		Headers:    http.Header{},
-		mutex:      &sync.Mutex{},
+		mutex:      sync.Mutex{},
 	}
 }
 
@@ -35,7 +35,7 @@ type CustomWriter struct {
 	Req         *http.Request
 	Headers     http.Header
 	headersSent bool
-	mutex       *sync.Mutex
+	mutex       sync.Mutex
 	statusCode  int
 }
 

--- a/pkg/surrogate/providers/common.go
+++ b/pkg/surrogate/providers/common.go
@@ -104,7 +104,7 @@ type baseStorage struct {
 	dynamic    bool
 	keepStale  bool
 	logger     core.Logger
-	mu         *sync.Mutex
+	mu         sync.Mutex
 	duration   time.Duration
 }
 
@@ -159,7 +159,6 @@ func (s *baseStorage) init(config configurationtypes.AbstractConfigurationInterf
 	s.dynamic = config.GetDefaultCache().GetCDN().Dynamic
 	s.logger = config.GetLogger()
 	s.keysRegexp = keysRegexp
-	s.mu = &sync.Mutex{}
 	s.duration = storageToInfiniteTTLMap[s.Storage.Name()]
 }
 

--- a/pkg/surrogate/providers/common_test.go
+++ b/pkg/surrogate/providers/common_test.go
@@ -30,7 +30,7 @@ func mockCommonProvider() *baseStorage {
 			Keys:       make(map[string]configurationtypes.SurrogateKeys),
 			keysRegexp: make(map[string]keysRegexpInner),
 			dynamic:    true,
-			mu:         &sync.Mutex{},
+			mu:         sync.Mutex{},
 			logger:     zap.NewNop().Sugar(),
 		},
 	}

--- a/plugins/traefik/override/middleware/writer.go
+++ b/plugins/traefik/override/middleware/writer.go
@@ -23,7 +23,7 @@ func NewCustomWriter(rq *http.Request, rw http.ResponseWriter, b *bytes.Buffer) 
 		Req:        rq,
 		Rw:         rw,
 		Headers:    http.Header{},
-		mutex:      &sync.Mutex{},
+		mutex:      sync.Mutex{},
 	}
 }
 
@@ -34,7 +34,7 @@ type CustomWriter struct {
 	Req         *http.Request
 	Headers     http.Header
 	headersSent bool
-	mutex       *sync.Mutex
+	mutex       sync.Mutex
 	statusCode  int
 }
 

--- a/plugins/traefik/override/surrogate/providers/common.go
+++ b/plugins/traefik/override/surrogate/providers/common.go
@@ -79,7 +79,7 @@ type baseStorage struct {
 	keysRegexp map[string]keysRegexpInner
 	dynamic    bool
 	keepStale  bool
-	mu         *sync.Mutex
+	mu         sync.Mutex
 	duration   time.Duration
 }
 
@@ -116,7 +116,7 @@ func (s *baseStorage) init(config configurationtypes.AbstractConfigurationInterf
 
 	s.dynamic = config.GetDefaultCache().GetCDN().Dynamic
 	s.keysRegexp = keysRegexp
-	s.mu = &sync.Mutex{}
+	s.mu = sync.Mutex{}
 	s.duration = storageToInfiniteTTLMap[s.Storage.Name()]
 }
 

--- a/plugins/traefik/vendor/github.com/darkweak/souin/pkg/middleware/writer.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/pkg/middleware/writer.go
@@ -23,7 +23,7 @@ func NewCustomWriter(rq *http.Request, rw http.ResponseWriter, b *bytes.Buffer) 
 		Req:        rq,
 		Rw:         rw,
 		Headers:    http.Header{},
-		mutex:      &sync.Mutex{},
+		mutex:      sync.Mutex{},
 	}
 }
 
@@ -34,7 +34,7 @@ type CustomWriter struct {
 	Req         *http.Request
 	Headers     http.Header
 	headersSent bool
-	mutex       *sync.Mutex
+	mutex       sync.Mutex
 	statusCode  int
 }
 

--- a/plugins/traefik/vendor/github.com/darkweak/souin/pkg/surrogate/providers/common.go
+++ b/plugins/traefik/vendor/github.com/darkweak/souin/pkg/surrogate/providers/common.go
@@ -79,7 +79,7 @@ type baseStorage struct {
 	keysRegexp map[string]keysRegexpInner
 	dynamic    bool
 	keepStale  bool
-	mu         *sync.Mutex
+	mu         sync.Mutex
 	duration   time.Duration
 }
 
@@ -116,7 +116,7 @@ func (s *baseStorage) init(config configurationtypes.AbstractConfigurationInterf
 
 	s.dynamic = config.GetDefaultCache().GetCDN().Dynamic
 	s.keysRegexp = keysRegexp
-	s.mu = &sync.Mutex{}
+	s.mu = sync.Mutex{}
 	s.duration = storageToInfiniteTTLMap[s.Storage.Name()]
 }
 

--- a/plugins/tyk/override/cache/surrogate/providers/common.go
+++ b/plugins/tyk/override/cache/surrogate/providers/common.go
@@ -72,7 +72,7 @@ type baseStorage struct {
 	dynamic    bool
 	keepStale  bool
 	logger     *zap.Logger
-	mu         *sync.Mutex
+	mu         sync.Mutex
 }
 
 func (s *baseStorage) init(config configurationtypes.AbstractConfigurationInterface) {
@@ -103,7 +103,7 @@ func (s *baseStorage) init(config configurationtypes.AbstractConfigurationInterf
 	s.dynamic = config.GetDefaultCache().GetCDN().Dynamic
 	s.logger = config.GetLogger()
 	s.keysRegexp = keysRegexp
-	s.mu = &sync.Mutex{}
+	s.mu = sync.Mutex{}
 }
 
 func (s *baseStorage) storeTag(tag string, cacheKey string, re *regexp.Regexp) {


### PR DESCRIPTION
Add the ability to the upstream to select its own storage using the HTTP response header `X-Souin-Storer`.  
e.g. `X-Souin-Storer: otter`.