### PR TITLE
fix(storage): head requests not cached

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -350,7 +350,7 @@ func (s *SouinBaseHandler) Store(
 		}
 		res.Header.Set(rfc.StoredLengthHeader, res.Header.Get("Content-Length"))
 		response, err := httputil.DumpResponse(&res, true)
-		if err == nil && (bLen > 0 || canStatusCodeEmptyContent(statusCode) || s.hasAllowedAdditionalStatusCodesToCache(statusCode)) {
+		if err == nil && (bLen > 0 || rq.Method == http.MethodHead || canStatusCodeEmptyContent(statusCode) || s.hasAllowedAdditionalStatusCodesToCache(statusCode)) {
 			variedHeaders, isVaryStar := rfc.VariedHeaderAllCommaSepValues(res.Header)
 			if isVaryStar {
 				// "Implies that the response is uncacheable"


### PR DESCRIPTION
related: https://github.com/caddyserver/cache-handler/issues/112#issuecomment-3159754093

TLDR: I'm getting `UPSTREAM-ERROR-OR-EMPTY-RESPONSE` for all HEAD requests even though I've included HEAD in `allowed_http_verbs` configuration.

```caddyfile
{
        cache {
                log_level DEBUG
                badger
                allowed_http_verbs GET HEAD
                default_cache_control public
        }

        log {
                level DEBUG
        }
}

http://localhost:3000 {
        cache {
                ttl 10s
        }
        respond "hello world" 200
}
```

After the fix:

```console
$ curl --head http://localhost:3000/
HTTP/1.1 200 OK
Cache-Control: public
Cache-Status: Souin; fwd=uri-miss; stored; key=HEAD-http-localhost:3000-/
Content-Length: 11
Content-Type: text/plain; charset=utf-8
Server: Caddy
Date: Wed, 06 Aug 2025 12:23:25 GMT
$ curl --head http://localhost:3000/
HTTP/1.1 200 OK
Age: 1
Cache-Control: public
Cache-Status: Souin; hit; ttl=9; key=HEAD-http-localhost:3000-/; detail=BADGER
Content-Length: 11
Content-Type: text/plain; charset=utf-8
Date: Wed, 06 Aug 2025 12:24:11 GMT
Server: Caddy
```