### PR TITLE
DefaultProvider DeleteMany regex fix & Caddy API admin requirement doc update

### DIFF
--- a/pkg/api/souin.go
+++ b/pkg/api/souin.go
@@ -212,6 +212,7 @@ func (s *SouinAPI) purgeMapping() {
 
 // HandleRequest will handle the request
 func (s *SouinAPI) HandleRequest(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("SOUIN API HandleRequest: Method=%s, URI=%s\n", r.Method, r.RequestURI)
 	res := []byte{}
 	compile := regexp.MustCompile(s.GetBasePath()+"/.+").FindString(r.RequestURI) != ""
 	switch r.Method {
@@ -322,7 +323,9 @@ func (s *SouinAPI) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				s.purgeMapping()
 			} else {
 				submatch := keysRg.FindAllStringSubmatch(r.RequestURI, -1)[0][1]
+				fmt.Printf("SOUIN API PURGE: extracted pattern from URI: %s\n", submatch)
 				for _, current := range s.storers {
+					fmt.Printf("SOUIN API PURGE: calling DeleteMany with pattern: %s on storer: %s\n", submatch, current.Name())
 					current.DeleteMany(submatch)
 				}
 			}

--- a/pkg/api/souin.go
+++ b/pkg/api/souin.go
@@ -121,6 +121,12 @@ func (s *SouinAPI) Delete(key string) {
 func (s *SouinAPI) GetAll() []string {
 	keys := []string{}
 	fmt.Printf("SOUIN API GetAll: Number of storers: %d\n", len(s.storers))
+	
+	if len(s.storers) == 0 {
+		fmt.Printf("SOUIN API GetAll: No storers configured - this suggests the HTTP cache handler hasn't been initialized yet or no storage is configured\n")
+		return keys
+	}
+	
 	for i, current := range s.storers {
 		currentKeys := current.ListKeys()
 		fmt.Printf("SOUIN API GetAll: Storer %d (%s) has %d keys\n", i, current.Name(), len(currentKeys))

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -149,6 +149,11 @@ func NewHTTPCacheHandler(c configurationtypes.AbstractConfigurationInterface) *S
 		Headers:             c.GetDefaultCache().GetHeaders(),
 		DefaultCacheControl: c.GetDefaultCache().GetDefaultCacheControl(),
 	}
+	if c.GetDefaultCache().IsCoalescingDisable() {
+		c.GetLogger().Info("Coalescing is disabled.")
+	} else {
+		c.GetLogger().Info("Coalescing is enabled.")
+	}
 	c.GetLogger().Info("Souin configuration is now loaded.")
 
 	registerMappingKeysEviction(c.GetLogger(), storers)

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -149,11 +149,6 @@ func NewHTTPCacheHandler(c configurationtypes.AbstractConfigurationInterface) *S
 		Headers:             c.GetDefaultCache().GetHeaders(),
 		DefaultCacheControl: c.GetDefaultCache().GetDefaultCacheControl(),
 	}
-	if c.GetDefaultCache().IsCoalescingDisable() {
-		c.GetLogger().Info("Coalescing is disabled.")
-	} else {
-		c.GetLogger().Info("Coalescing is enabled.")
-	}
 	c.GetLogger().Info("Souin configuration is now loaded.")
 
 	registerMappingKeysEviction(c.GetLogger(), storers)

--- a/pkg/storage/defaultProvider.go
+++ b/pkg/storage/defaultProvider.go
@@ -191,7 +191,7 @@ func (provider *Default) DeleteMany(key string) {
 
 	provider.m.Range(func(current, _ any) bool {
 		if (re != nil && re.MatchString(current.(string))) || strings.HasPrefix(current.(string), key) {
-			provider.m.Delete(current.(string))
+			provider.m.Delete(current)
 		}
 
 		return true

--- a/pkg/storage/defaultProvider.go
+++ b/pkg/storage/defaultProvider.go
@@ -191,7 +191,7 @@ func (provider *Default) DeleteMany(key string) {
 
 	provider.m.Range(func(current, _ any) bool {
 		if (re != nil && re.MatchString(current.(string))) || strings.HasPrefix(current.(string), key) {
-			provider.m.Delete(key)
+			provider.m.Delete(current.(string))
 		}
 
 		return true

--- a/plugins/caddy/README.md
+++ b/plugins/caddy/README.md
@@ -154,6 +154,9 @@ handle @match {
 }
 ```
 
+### API Setup
+Along with ensuring the Souin API is enabled in the global options, the API is only accessible via the [Caddy admin API](https://caddyserver.com/docs/api) since Souin v1.7.7. For example, if using the default admin port (:2019) and Souin API base paths, the Souin API would be accessible via http://localhost:2019/souin-api/souin
+
 ## Provider Syntax
 
 ### Badger

--- a/plugins/caddy/httpcache.go
+++ b/plugins/caddy/httpcache.go
@@ -216,6 +216,9 @@ func (s *SouinCaddyMiddleware) FromApp(app *SouinApp) error {
 	if dc.CacheName == "" {
 		s.Configuration.DefaultCache.CacheName = appDc.CacheName
 	}
+	if !dc.DisableCoalescing && appDc.DisableCoalescing {
+		s.Configuration.DefaultCache.DisableCoalescing = appDc.DisableCoalescing
+	}
 	if isProviderEmpty(dc.Badger) && isProviderEmpty(dc.Etcd) && isProviderEmpty(dc.Nats) && isProviderEmpty(dc.Nuts) && isProviderEmpty(dc.Olric) && isProviderEmpty(dc.Otter) && isProviderEmpty(dc.Redis) && isProviderEmpty(dc.SimpleFS) {
 		s.Configuration.DefaultCache.Distributed = appDc.Distributed
 		s.Configuration.DefaultCache.Olric = appDc.Olric


### PR DESCRIPTION
When using the DefaultProvider for storage, keys and regex deletion was not working due to passing the regex instead of the found key in DeleteMany.

Also, since 1.7.7, the Souin API is only accessible via the Caddy Admin API, which requires additional setup. This is now noted in the docs for Caddy.