### PR TITLE
Fix storeTag regex performance bottleneck

### DIFF
--- a/pkg/surrogate/providers/common.go
+++ b/pkg/surrogate/providers/common.go
@@ -162,11 +162,37 @@ func (s *baseStorage) init(config configurationtypes.AbstractConfigurationInterf
 	s.duration = storageToInfiniteTTLMap[s.Storage.Name()]
 }
 
-func (s *baseStorage) storeTag(tag string, cacheKey string, re *regexp.Regexp) {
+// containsCacheKey checks if the cacheKey already exists in the comma-separated currentValue.
+// This is much faster than regex matching, especially for long strings.
+func containsCacheKey(currentValue, cacheKey string) bool {
+	if currentValue == "" {
+		return false
+	}
+	// Check for exact match at various positions:
+	// 1. Exact match of entire string
+	if currentValue == cacheKey {
+		return true
+	}
+	// 2. At the beginning: "cacheKey,"
+	if strings.HasPrefix(currentValue, cacheKey+souinStorageSeparator) {
+		return true
+	}
+	// 3. At the end: ",cacheKey"
+	if strings.HasSuffix(currentValue, souinStorageSeparator+cacheKey) {
+		return true
+	}
+	// 4. In the middle: ",cacheKey,"
+	if strings.Contains(currentValue, souinStorageSeparator+cacheKey+souinStorageSeparator) {
+		return true
+	}
+	return false
+}
+
+func (s *baseStorage) storeTag(tag string, cacheKey string) {
 	defer s.mu.Unlock()
 	s.mu.Lock()
 	currentValue := string(s.Storage.Get(surrogatePrefix + tag))
-	if !re.MatchString(currentValue) {
+	if !containsCacheKey(currentValue, cacheKey) {
 		s.logger.Debugf("Store the tag %s", tag)
 		_ = s.Storage.Set(surrogatePrefix+tag, []byte(currentValue+souinStorageSeparator+cacheKey), s.duration)
 	}
@@ -222,29 +248,28 @@ func (s *baseStorage) Store(response *http.Response, cacheKey, uri string) error
 
 	cacheKey = url.QueryEscape(cacheKey)
 
-	urlRegexp := regexp.MustCompile("(^|" + regexp.QuoteMeta(souinStorageSeparator) + ")" + regexp.QuoteMeta(cacheKey) + "(" + regexp.QuoteMeta(souinStorageSeparator) + "|$)")
 	keys := s.ParseHeaders(s.parent.getSurrogateKey(h))
 
 	for _, key := range keys {
 		_, v := s.parent.GetSurrogateControl(h)
 		if controls := s.ParseHeaders(v); len(controls) != 0 {
 			if len(controls) == 1 && controls[0] == "" {
-				s.storeTag(key, cacheKey, urlRegexp)
-				s.storeTag(uri, cacheKey, urlRegexp)
+				s.storeTag(key, cacheKey)
+				s.storeTag(uri, cacheKey)
 
 				continue
 			}
 			for _, control := range controls {
 				if s.parent.candidateStore(control) {
-					s.storeTag(key, cacheKey, urlRegexp)
-					s.storeTag(uri, cacheKey, urlRegexp)
+					s.storeTag(key, cacheKey)
+					s.storeTag(uri, cacheKey)
 
 					break
 				}
 			}
 		} else {
-			s.storeTag(key, cacheKey, urlRegexp)
-			s.storeTag(uri, cacheKey, urlRegexp)
+			s.storeTag(key, cacheKey)
+			s.storeTag(uri, cacheKey)
 		}
 	}
 

--- a/pkg/surrogate/providers/types.go
+++ b/pkg/surrogate/providers/types.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"net/http"
-	"regexp"
 )
 
 // SurrogateInterface represents the interface to implement to be part
@@ -17,7 +16,7 @@ type SurrogateInterface interface {
 	Invalidate(method string, h http.Header)
 	purgeTag(string) []string
 	Store(*http.Response, string, string) error
-	storeTag(string, string, *regexp.Regexp)
+	storeTag(string, string)
 	ParseHeaders(string) []string
 	List() map[string]string
 	candidateStore(string) bool


### PR DESCRIPTION
Fixes https://github.com/darkweak/souin/issues/696

## Warning: This was entirely done by Claude Code

### Problem

The `storeTag` function was using regex matching to check for duplicate cache keys in the stored comma-separated list. This caused ~57% CPU consumption because:

1. A regex was compiled on every `Store()` call
2. The regex was executed against potentially very long strings containing thousands of cache keys
3. Regex backtracking is O(n×m) complexity

### Solution

Replace regex matching with simple string operations (`strings.HasPrefix`, `strings.HasSuffix`, `strings.Contains`) that provide O(n) complexity and leverage Go's optimized `strings` package.

### Changes

- Added `containsCacheKey()` helper function using fast string operations
- Removed regex parameter from `storeTag()` 
- Removed per-request `regexp.MustCompile()` calls from `Store()`
- Updated `SurrogateInterface` to reflect new signature
- Added unit tests for `containsCacheKey()` covering edge cases
- Applied same fix to traefik and tyk plugin overrides