### PR TITLE
Improve redis eviction mechanisms using sorted sets

### DIFF
--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -26,3 +26,15 @@ type Storer interface {
 	GetMultiLevel(key string, req *http.Request, validator *core.Revalidator) (fresh *http.Response, stale *http.Response)
 	SetMultiLevel(baseKey, variedKey string, value []byte, variedHeaders http.Header, etag string, duration time.Duration, realKey string) error
 }
+
+// MappingEvictor is an optional interface that storers can implement to provide
+// efficient mapping eviction without requiring SCAN operations.
+// Storers that implement this interface (e.g., Redis with sorted sets) can handle
+// expired mapping entry cleanup more efficiently than the default SCAN-based approach.
+// See: https://github.com/darkweak/souin/issues/671
+type MappingEvictor interface {
+	// EvictExpiredMappingEntries removes expired entries from mapping keys.
+	// Returns true if the storer handles eviction natively (no further action needed).
+	// Returns false if the default SCAN-based eviction should be used.
+	EvictExpiredMappingEntries() bool
+}


### PR DESCRIPTION
Fixes #671

#### Problem
The current implementation uses Redis `SCAN` commands to iterate over all mapping keys (`IDX_*`) every minute to evict expired entries. This causes excessive Redis command overhead, particularly problematic for managed Redis services (Upstash, Redis Cloud, etc.) where it impacts billing and performance.

#### Solution
Replace SCAN-based eviction with Redis Sorted Sets (ZSET) for efficient expiration tracking:

1. **New sorted set index** (`IDX_TIMESTAMPS`): When storing cache entries, we now also add an entry to a sorted set with the `staleTime` as the score
2. **Efficient eviction**: Instead of SCAN, use `ZRANGEBYSCORE IDX_TIMESTAMPS -inf <now>` to retrieve only expired entries
3. **Optional interface**: Added `MappingEvictor` interface so storers can opt-in to efficient eviction while maintaining backward compatibility

#### Performance comparison
| Operation | Before (SCAN) | After (ZSET) |
|-----------|---------------|--------------|
| Find expired entries | O(N) all keys | O(log N + M) expired only |
| Redis commands/minute | Many SCAN iterations | 1 ZRANGEBYSCORE + 1 ZREM |

#### Changes

**souin repository:**
- `pkg/storage/types/types.go`: Added `MappingEvictor` interface
- `pkg/api/souin.go`: Modified `EvictMapping()` to use `MappingEvictor` when available

**storages repository:**
- `redis/redis.go`: Implemented `EvictExpiredMappingEntries()` using sorted sets
- `go-redis/go-redis.go`: Same implementation for go-redis client

#### Migration
- No breaking changes - existing data continues to work
- New entries are automatically indexed in the sorted set
- Storers without `MappingEvictor` fall back to existing SCAN behavior