### PR TITLE
fix(caddy): move ResetRegisteredStorages from Start to Stop

### DIFF
--- a/plugins/caddy/app.go
+++ b/plugins/caddy/app.go
@@ -47,7 +47,6 @@ func (s *SouinApp) Provision(_ caddy.Context) error {
 
 // Start will start the App
 func (s SouinApp) Start() error {
-	core.ResetRegisteredStorages()
 	_, _ = up.Delete(stored_providers_key)
 	_, _ = up.LoadOrStore(stored_providers_key, newStorageProvider())
 
@@ -56,6 +55,8 @@ func (s SouinApp) Start() error {
 
 // Stop will stop the App
 func (s SouinApp) Stop() error {
+	core.ResetRegisteredStorages()
+
 	return nil
 }
 


### PR DESCRIPTION
Move the storage cleanup to Stop() so that:
1. Initial startup works correctly (middleware registers storers first)
2. Reload properly cleans up old storage connections

Previously ResetRegisteredStorages was called in Start(), which cleared the storages that were just registered by middleware during Provision.

Relates: #723