### PR TITLE
fix(caddy): badger dir and vdir should fallback to path

### DIFF
--- a/plugins/caddy/dispatch.go
+++ b/plugins/caddy/dispatch.go
@@ -15,8 +15,8 @@ func (s *SouinCaddyMiddleware) parseStorages(ctx caddy.Context) {
 			s.logger.Errorf("Error during Badger init, did you include the Badger storage (--with github.com/darkweak/storages/badger/caddy)? %v", e)
 		} else {
 			badger := s.Configuration.DefaultCache.Badger
-			dir := ""
-			vdir := ""
+			dir := badger.Path
+			vdir := badger.Path
 			if c := badger.Configuration; c != nil {
 				p, ok := c.(map[string]interface{})
 				if ok {


### PR DESCRIPTION
Perhaps we should use a shared UUID generation system between souin and storages, but this one works for now.