### PR TITLE
fix(middleware): serve range requests via http.ServeContent

### DIFF
--- a/pkg/middleware/writer.go
+++ b/pkg/middleware/writer.go
@@ -2,11 +2,10 @@ package middleware
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"sync"
+	"time"
 
 	"github.com/darkweak/go-esi/esi"
 	"github.com/darkweak/souin/pkg/rfc"
@@ -87,59 +86,6 @@ func (r *CustomWriter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-type rangeValue struct {
-	from, to int64
-}
-
-const separator = "--SOUIN-HTTP-CACHE-SEPARATOR"
-
-func parseRange(rangeHeaders []string, contentRange string) ([]rangeValue, rangeValue, int64) {
-	if len(rangeHeaders) == 0 {
-		return nil, rangeValue{}, -1
-	}
-
-	crv := rangeValue{from: 0, to: 0}
-	var total int64 = -1
-	if contentRange != "" {
-		crVal := strings.Split(strings.TrimPrefix(contentRange, "bytes "), "/")
-		total, _ = strconv.ParseInt(crVal[1], 10, 64)
-		total--
-
-		crSplit := strings.Split(crVal[0], "-")
-		crv.from, _ = strconv.ParseInt(crSplit[0], 10, 64)
-		crv.to, _ = strconv.ParseInt(crSplit[1], 10, 64)
-	}
-
-	values := make([]rangeValue, len(rangeHeaders))
-
-	for idx, header := range rangeHeaders {
-		ranges := strings.Split(header, "-")
-		rv := rangeValue{from: -1, to: total}
-
-		// e.g. Range: -5
-		if len(ranges) == 2 && ranges[0] == "" {
-			ranges[0] = "-" + ranges[1]
-			from, _ := strconv.ParseInt(ranges[0], 10, 64)
-			rv.from = total + from
-
-			values[idx] = rv
-
-			continue
-		}
-
-		rv.from, _ = strconv.ParseInt(ranges[0], 10, 64)
-
-		if ranges[1] != "" {
-			rv.to, _ = strconv.ParseInt(ranges[1], 10, 64)
-			rv.to++
-		}
-
-		values[idx] = rv
-	}
-
-	return values, crv, total + 1
-}
-
 // Send delays the response to handle Cache-Status
 func (r *CustomWriter) Send() (int, error) {
 	defer r.handleBuffer(func(b *bytes.Buffer) {
@@ -150,73 +96,46 @@ func (r *CustomWriter) Send() (int, error) {
 		r.Header().Set("Content-Length", storedLength)
 	}
 
-	result := r.Buf.Bytes()
+	result := esi.Parse(r.Buf.Bytes(), r.Req)
 
-	result = esi.Parse(result, r.Req)
+	r.Header().Del(rfc.StoredLengthHeader)
+	r.Header().Del(rfc.StoredTTLHeader)
 
-	if r.Headers.Get("Range") != "" {
+	// When the client issued a range request, serve it from the fully cached
+	// body through the standard library. http.ServeContent implements RFC 7233
+	// in full (single/suffix/multipart ranges, If-Range, 416 with Content-Range,
+	// Accept-Ranges and CRLF-delimited multipart payloads), which avoids the
+	// off-by-one and out-of-bounds issues of a hand-rolled implementation.
+	if rangeHeader := r.Headers.Get("Range"); rangeHeader != "" && r.GetStatusCode() == http.StatusOK && !r.headersSent {
+		r.Header().Set("Accept-Ranges", "bytes")
 
-		var bufStr string
-		mimeType := r.Header().Get("Content-Type")
-
-		r.WriteHeader(http.StatusPartialContent)
-
-		rangeHeader, contentRangeValue, total := parseRange(
-			strings.Split(strings.TrimPrefix(r.Headers.Get("Range"), "bytes="), ", "),
-			r.Header().Get("Content-Range"),
-		)
-		bodyBytes := r.Buf.Bytes()
-		bufLen := int64(r.Buf.Len())
-		if total > 0 {
-			bufLen = total
+		// ServeContent reads Range/If-Range from the request. Build a minimal
+		// request carrying only those headers so it doesn't re-evaluate the
+		// conditional headers Souin already handled upstream.
+		rangeReq := &http.Request{Method: r.Req.Method, Header: http.Header{"Range": {rangeHeader}}}
+		if ifRange := r.Req.Header.Get("If-Range"); ifRange != "" {
+			rangeReq.Header.Set("If-Range", ifRange)
 		}
 
-		if len(rangeHeader) == 1 {
-			header := rangeHeader[0]
-			internalFrom := (header.from - contentRangeValue.from) % bufLen
-			internalTo := (header.to - contentRangeValue.from) % bufLen
-
-			content := bodyBytes[internalFrom:]
-
-			r.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", contentRangeValue.from, contentRangeValue.to, bufLen))
-
-			if internalTo >= 0 {
-				content = content[:internalTo-internalFrom]
-				r.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", header.from, header.to, bufLen))
+		// Last-Modified lets ServeContent evaluate a date-based If-Range.
+		var modtime time.Time
+		if lastModified := r.Header().Get("Last-Modified"); lastModified != "" {
+			if parsed, err := http.ParseTime(lastModified); err == nil {
+				modtime = parsed
 			}
-
-			result = content
 		}
 
-		if len(rangeHeader) > 1 {
-			r.Header().Set("Content-Type", "multipart/byteranges; boundary="+separator)
+		r.headersSent = true
+		// An empty name skips extension-based sniffing so the cached
+		// Content-Type is preserved.
+		http.ServeContent(r.Rw, rangeReq, "", modtime, bytes.NewReader(result))
 
-			for _, header := range rangeHeader {
-
-				content := bodyBytes[header.from:]
-				if header.to >= 0 {
-					content = content[:header.to-header.from]
-				}
-
-				bufStr += fmt.Sprintf(`
-%s
-Content-Type: %s
-Content-Range: bytes %d-%d/%d
-
-%s
-`, separator, mimeType, header.from, header.to, r.Buf.Len(), content)
-			}
-
-			result = []byte(bufStr + separator + "--")
-		}
+		return len(result), nil
 	}
 
 	if len(result) != 0 {
 		r.Header().Set("Content-Length", strconv.Itoa(len(result)))
 	}
-
-	r.Header().Del(rfc.StoredLengthHeader)
-	r.Header().Del(rfc.StoredTTLHeader)
 
 	if !r.headersSent {
 		r.Rw.WriteHeader(r.GetStatusCode())

--- a/pkg/middleware/writer_test.go
+++ b/pkg/middleware/writer_test.go
@@ -1,0 +1,119 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// sendWithRange builds a CustomWriter holding the given body, simulates the
+// stashed Range header (see ServeHTTP) and returns the result of Send().
+func sendWithRange(t *testing.T, body, rangeHeader string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/segment.ts", nil)
+	cw := NewCustomWriter(req, rec, &bytes.Buffer{})
+	rec.Header().Set("Content-Type", "video/mp2t")
+	if rangeHeader != "" {
+		cw.Headers.Set("Range", rangeHeader)
+	}
+	_, _ = cw.Write([]byte(body))
+	if _, err := cw.Send(); err != nil {
+		t.Fatalf("Send returned an error: %v", err)
+	}
+
+	return rec
+}
+
+func TestSend_NoRangeServesFullBody(t *testing.T) {
+	rec := sendWithRange(t, "0123456789", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != "0123456789" {
+		t.Fatalf("expected full body, got %q", rec.Body.String())
+	}
+	if rec.Header().Get("Content-Range") != "" {
+		t.Fatalf("unexpected Content-Range on a non-range response")
+	}
+}
+
+func TestSend_SingleRange(t *testing.T) {
+	rec := sendWithRange(t, "0123456789", "bytes=0-3")
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("expected 206, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != "0123" {
+		t.Fatalf("expected %q, got %q", "0123", got)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "bytes 0-3/10" {
+		t.Fatalf("expected Content-Range %q, got %q", "bytes 0-3/10", got)
+	}
+	if got := rec.Header().Get("Accept-Ranges"); got != "bytes" {
+		t.Fatalf("expected Accept-Ranges bytes, got %q", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "video/mp2t" {
+		t.Fatalf("cached Content-Type should be preserved, got %q", got)
+	}
+}
+
+func TestSend_OpenEndedRange(t *testing.T) {
+	rec := sendWithRange(t, "0123456789", "bytes=5-")
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("expected 206, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != "56789" {
+		t.Fatalf("expected %q, got %q", "56789", got)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "bytes 5-9/10" {
+		t.Fatalf("expected Content-Range %q, got %q", "bytes 5-9/10", got)
+	}
+}
+
+func TestSend_SuffixRange(t *testing.T) {
+	rec := sendWithRange(t, "0123456789", "bytes=-3")
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("expected 206, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != "789" {
+		t.Fatalf("expected %q, got %q", "789", got)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "bytes 7-9/10" {
+		t.Fatalf("expected Content-Range %q, got %q", "bytes 7-9/10", got)
+	}
+}
+
+func TestSend_UnsatisfiableRange(t *testing.T) {
+	rec := sendWithRange(t, "0123456789", "bytes=100-200")
+
+	if rec.Code != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("expected 416, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Range"); got != "bytes */10" {
+		t.Fatalf("expected Content-Range %q, got %q", "bytes */10", got)
+	}
+}
+
+func TestSend_MultipartRange(t *testing.T) {
+	rec := sendWithRange(t, "0123456789", "bytes=0-1, 4-5")
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("expected 206, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct == "" ||
+		!bytes.Contains([]byte(ct), []byte("multipart/byteranges")) {
+		t.Fatalf("expected multipart/byteranges Content-Type, got %q", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"bytes 0-1/10", "bytes 4-5/10", "01", "45"} {
+		if !bytes.Contains([]byte(body), []byte(want)) {
+			t.Fatalf("multipart body missing %q; got:\n%s", want, body)
+		}
+	}
+}

--- a/plugins/caddy/httpcache_test.go
+++ b/plugins/caddy/httpcache_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1482,19 +1486,16 @@ func TestRange(t *testing.T) {
 	reqRange, _ := http.NewRequest(http.MethodGet, "http://localhost:9080/range-request", nil)
 	reqRange.Header.Set("Range", "bytes=0-4, 6-10")
 
-	resp1, _ := tester.AssertResponse(reqRange, http.StatusPartialContent, `
---SOUIN-HTTP-CACHE-SEPARATOR
-Content-Type: text/plain; charset=utf-8
-Content-Range: bytes 0-5/20
+	// The multipart byteranges payload is produced by http.ServeContent, whose
+	// boundary is randomly generated per response, so the body cannot be matched
+	// verbatim. Parse the multipart instead and assert the individual parts.
+	wantParts := []rangePart{
+		{contentRange: "bytes 0-4/20", body: "Hello"},
+		{contentRange: "bytes 6-10/20", body: "range"},
+	}
 
-Hello
-
---SOUIN-HTTP-CACHE-SEPARATOR
-Content-Type: text/plain; charset=utf-8
-Content-Range: bytes 6-11/20
-
-range
---SOUIN-HTTP-CACHE-SEPARATOR--`)
+	resp1 := tester.AssertResponseCode(reqRange, http.StatusPartialContent)
+	assertMultipartRanges(t, resp1, wantParts)
 
 	if resp1.Header.Get("Cache-Status") != "Souin; fwd=uri-miss; stored; key=GET-http-localhost:9080-/range-request" {
 		t.Errorf("unexpected resp1 Cache-Status header %v", resp1.Header.Get("Cache-Status"))
@@ -1504,24 +1505,58 @@ range
 		t.Errorf("unexpected resp1 Age header %v", resp1.Header.Get("Age"))
 	}
 
-	resp2, _ := tester.AssertResponse(reqRange, http.StatusPartialContent, `
---SOUIN-HTTP-CACHE-SEPARATOR
-Content-Type: text/plain; charset=utf-8
-Content-Range: bytes 0-5/20
-
-Hello
-
---SOUIN-HTTP-CACHE-SEPARATOR
-Content-Type: text/plain; charset=utf-8
-Content-Range: bytes 6-11/20
-
-range
---SOUIN-HTTP-CACHE-SEPARATOR--`)
+	resp2 := tester.AssertResponseCode(reqRange, http.StatusPartialContent)
+	assertMultipartRanges(t, resp2, wantParts)
 
 	compareHit(t, resp2.Header, "GET-http-localhost:9080-/range-request", "DEFAULT", 119)
 
 	if resp2.Header.Get("Age") != "1" {
 		t.Errorf("unexpected resp2 Age header %v", resp2.Header.Get("Age"))
+	}
+}
+
+type rangePart struct {
+	contentRange string
+	body         string
+}
+
+// assertMultipartRanges parses a multipart/byteranges response body and asserts
+// the Content-Range header and payload of each part, ignoring the randomly
+// generated multipart boundary.
+func assertMultipartRanges(t *testing.T, resp *http.Response, want []rangePart) {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	mediaType, params, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("cannot parse Content-Type %q: %v", resp.Header.Get("Content-Type"), err)
+	}
+	if mediaType != "multipart/byteranges" {
+		t.Fatalf("expected multipart/byteranges Content-Type, got %q", mediaType)
+	}
+
+	mr := multipart.NewReader(resp.Body, params["boundary"])
+	got := make([]rangePart, 0, len(want))
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("reading multipart part: %v", err)
+		}
+
+		body, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("reading multipart part body: %v", err)
+		}
+
+		got = append(got, rangePart{contentRange: part.Header.Get("Content-Range"), body: string(body)})
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("unexpected multipart parts\n got: %#v\nwant: %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
Delegate to http.ServeContent, which handles RFC 7233 fully (single, suffix, open-ended and multipart ranges, If-Range, 416, Accept-Ranges). Add writer_test.go covering these cases.