### PR TITLE
fix(ci): bump Node to 22 and pin pnpm to 11.5.1

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -113,12 +113,12 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - uses: pnpm/action-setup@v3
         name: Install pnpm
         with:
-          version: latest
+          version: 11.5.1
       -
         name: Checkout Souin code
         uses: actions/checkout@v4

--- a/.github/workflows/workflow_plugins_generator.sh
+++ b/.github/workflows/workflow_plugins_generator.sh
@@ -121,12 +121,12 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - uses: pnpm/action-setup@v3
         name: Install pnpm
         with:
-          version: latest
+          version: 11.5.1
       -
         name: Checkout Souin code
         uses: actions/checkout@v4


### PR DESCRIPTION
pnpm 11 requires Node >=22.13, so on Node 18 the cache-tests server failed to start and the screenshot step failed with ERR_CONNECTION_REFUSED on 127.0.0.1:8000.

https://github.com/darkweak/souin/actions/runs/26663993199/job/79152784286?pr=795