### PR TITLE
feat(middleware): don't cache responses with a Set-Cookie header

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -387,6 +387,18 @@ func (s *SouinBaseHandler) Store(
 		return nil
 	}
 
+	// A Set-Cookie response is usually tied to a single user; storing it in a
+	// shared cache would replay one user's cookie to every subsequent client.
+	// RFC 9111 §7.3 allows caching such responses, but most reverse proxies
+	// (nginx, Varnish, Fastly, Cloudflare) treat them as uncacheable by default,
+	// so we never store them. The exception is an explicit no-cache="Set-Cookie"
+	// directive: the field is stripped from the stored response below, so there
+	// is nothing to leak and the rest of the response can still be cached.
+	if customWriter.Header().Get("Set-Cookie") != "" && !responseCc.NoCache["Set-Cookie"] {
+		customWriter.Header().Set("Cache-Status", fmt.Sprintf("%s; fwd=uri-miss; key=%s; detail=UNCACHEABLE-SET-COOKIE", rq.Context().Value(context.CacheName), rfc.GetCacheKeyFromCtx(rq.Context())))
+		return nil
+	}
+
 	currentMatchedURL := s.DefaultMatchedUrl
 	if regexpURL := s.RegexpUrls.FindString(rq.Host + rq.URL.Path); regexpURL != "" {
 		u := s.Configuration.GetUrls()[regexpURL]

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -401,3 +401,66 @@ func TestHopByHopHeadersAreNotCached(t *testing.T) {
 		}
 	}
 }
+
+// cacheableNext returns a handlerFunc writing a cacheable response, optionally
+// carrying a Set-Cookie header.
+func cacheableNext(body string, setCookie string) handlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		if setCookie != "" {
+			w.Header().Set("Set-Cookie", setCookie)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+		return nil
+	}
+}
+
+// TestSetCookieResponseIsNotStored ensures a response carrying a Set-Cookie
+// header is never written to the cache, so one user's cookie can't be replayed
+// to other clients. Most reverse proxies (nginx, Varnish, Fastly, Cloudflare)
+// treat such responses as uncacheable by default; Souin matches that.
+func TestSetCookieResponseIsNotStored(t *testing.T) {
+	handler, storer := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/with-cookie", nil)
+	rec := httptest.NewRecorder()
+
+	if err := handler.ServeHTTP(rec, req, cacheableNext("BODY", "session=abc123")); err != nil {
+		t.Fatalf("ServeHTTP failed: %v", err)
+	}
+
+	for _, k := range storer.ListKeys() {
+		if strings.Contains(k, "/with-cookie") {
+			t.Errorf("Set-Cookie response must not be stored, found key: %q", k)
+		}
+	}
+	if cs := rec.Header().Get("Cache-Status"); !strings.Contains(cs, "UNCACHEABLE-SET-COOKIE") {
+		t.Errorf("expected Cache-Status detail UNCACHEABLE-SET-COOKIE, got %q", cs)
+	}
+}
+
+// TestResponseWithoutSetCookieIsStored is the positive control for
+// TestSetCookieResponseIsNotStored: the same response without a Set-Cookie
+// header must still be cached, proving the guard is specific to Set-Cookie.
+func TestResponseWithoutSetCookieIsStored(t *testing.T) {
+	handler, storer := newTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/no-cookie", nil)
+	rec := httptest.NewRecorder()
+
+	if err := handler.ServeHTTP(rec, req, cacheableNext("BODY", "")); err != nil {
+		t.Fatalf("ServeHTTP failed: %v", err)
+	}
+
+	stored := false
+	for _, k := range storer.ListKeys() {
+		if strings.Contains(k, "/no-cookie") {
+			stored = true
+			break
+		}
+	}
+	if !stored {
+		t.Error("a cacheable response without Set-Cookie should be stored, found no matching key")
+	}
+}


### PR DESCRIPTION
A Set-Cookie response is typically tied to a single user; storing it in a shared cache replays one user's cookie to every subsequent client. Match the default of nginx/Varnish/Fastly/Cloudflare and skip storing such responses (detail=UNCACHEABLE-SET-COOKIE).

Closes #805